### PR TITLE
fix: Add required permissions for CodeQL Analysis job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,10 @@ jobs:
     name: CodeQL Analysis
     timeout-minutes: 10
     needs: [setup]
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Fixed CodeQL Analysis job failing with "Resource not accessible by integration" error
- Added required permissions: `security-events: write`, `contents: read`, and `actions: read`
- Resolves CI failure where CodeQL couldn't upload security analysis results

## Test plan
- [x] Created branch and committed changes
- [ ] Wait for CI to run and verify CodeQL Analysis passes
- [ ] Confirm all other CI jobs continue to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)