### PR TITLE
feat(domain): implement event sourcing for Game, TeamLineup, and InningState aggregates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,30 +1,42 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
 
 ## Project Overview
 
-**TW Softball** - A slow-pitch softball game recording Progressive Web App (PWA) with offline-first capabilities, built using Hexagonal Architecture and Event Sourcing patterns.
+**TW Softball** - A slow-pitch softball game recording Progressive Web App (PWA)
+with offline-first capabilities, built using Hexagonal Architecture and Event
+Sourcing patterns.
 
 ## Quick Reference (AI: Read This First)
 
 ### 🔴 CRITICAL - Always Follow These Rules
+
 - **ALWAYS use TodoWrite** for task tracking and progress management
 - **ALWAYS run commit-readiness-reviewer** before any git commit
 - **ALWAYS complete Post-Commit Checklist** after EVERY commit
+- **ALWAYS typecheck, lint, format, and test** after a worker finished a job and
+  fix errors right away
 - **NEVER create workarounds** - raise issues after 3 failed attempts
-- **NEVER compromise on code quality** - no shortcuts, quick fixes, or technical debt
+- **NEVER compromise on code quality** - no shortcuts, quick fixes, or technical
+  debt
 - **NEVER import infrastructure into application layer**
-- **ALWAYS use orchestrator-worker pattern** for complex tasks (Main Agent coordinates, General Agent implements)
+- **ALWAYS use orchestrator-worker pattern** for complex tasks (Main Agent
+  coordinates, General Agent implements)
 
 ### 🟡 IMPORTANT - Core Workflow
-1. Plan with TodoWrite → Delegate via Task tool → Review with commit-readiness-reviewer → Handle git operations → Complete Post-Commit Checklist
+
+1. Plan with TodoWrite → Delegate via Task tool → Review with
+   commit-readiness-reviewer → Handle git operations → Complete Post-Commit
+   Checklist
 2. Write tests before implementation (TDD)
 3. Follow existing patterns and conventions
 4. Achieve 99%+ test coverage for every layer
 5. After creating new files, run lint immediately and address issues right away
 
 ### 🟢 HELPFUL - Key Commands
+
 ```bash
 pnpm test                     # Run all tests
 pnpm typecheck                # TypeScript check
@@ -35,7 +47,8 @@ pnpm --filter @twsoftball/domain test    # Domain tests only
 
 ## Architecture
 
-**Hexagonal Architecture (Ports & Adapters) + Domain-Driven Design + SOLID Principles**
+**Hexagonal Architecture (Ports & Adapters) + Domain-Driven Design + SOLID
+Principles**
 
 ```
 Domain Layer (Core Business Logic)
@@ -57,7 +70,7 @@ Application Layer (Use Cases)
 
 Infrastructure Layer (Adapters)
 ├── persistence/  # IndexedDB, SQLite implementations
-├── auth/         # Authentication adapters  
+├── auth/         # Authentication adapters
 └── config/       # Dependency injection
 
 Web Layer (Presentation)
@@ -81,37 +94,47 @@ Web Layer (Presentation)
 
 ### Core 5-Step Workflow
 
-1. **Plan & Track** 
+1. **Plan & Track**
    - Main Agent creates TodoWrite list for complex tasks
    - Break work into focused, discrete units
 
 2. **Delegate Implementation**
-   - Main Agent assigns ALL implementation tasks to General-Purpose Agent via Task tool
+   - Main Agent assigns ALL implementation tasks to General-Purpose Agent via
+     Task tool
    - General-Purpose Agent implements using TDD (test → code → refactor)
 
 3. **Review & Validate**
    - Main Agent triggers commit-readiness-reviewer for quality validation
    - Main Agent summarizes review feedback and displays to user
-   - If issues found, delegate ALL fixes to General-Purpose Agent (max 3 attempts)
+   - If issues found, delegate ALL fixes to General-Purpose Agent (max 3
+     attempts)
 
 4. **Delegate Git Operations**
    - Main Agent delegates ALL git operations to General-Purpose Agent
-   - General-Purpose Agent handles git add, commit, pre-commit hook fixes, and PR creation
+   - General-Purpose Agent handles git add, commit, pre-commit hook fixes, and
+     PR creation
 
 5. **Delegate Documentation Updates**
    - Main Agent delegates Post-Commit Checklist to General-Purpose Agent
    - General-Purpose Agent updates relevant documentation
 
 ### Agent Roles
-- **Main Agent (Orchestrator)**: Plans with TodoWrite, delegates ALL work, triggers reviews, summarizes feedback, monitors progress, escalates issues only
-- **General-Purpose Agent (Worker)**: Implements ALL tasks with TDD, handles git operations, fixes issues, updates documentation, reports back with deliverables
-- **Commit-Readiness-Reviewer (Validator)**: Validates architecture, checks quality gates, returns detailed feedback for main agent to summarize
+
+- **Main Agent (Orchestrator)**: Plans with TodoWrite, delegates ALL work,
+  triggers reviews, summarizes feedback, monitors progress, escalates issues
+  only
+- **General-Purpose Agent (Worker)**: Implements ALL tasks with TDD, handles git
+  operations, fixes issues, updates documentation, reports back with
+  deliverables
+- **Commit-Readiness-Reviewer (Validator)**: Validates architecture, checks
+  quality gates, returns detailed feedback for main agent to summarize
 
 ## 📝 Post-Commit Checklist (DELEGATED TO GENERAL-PURPOSE AGENT)
 
 **After every commit, delegate this task to the General-Purpose Agent:**
 
 ### Essential Documentation Updates:
+
 1. Update architectural diagrams if package structure changed
 2. Add new scripts or commands discovered/created to documentation
 3. Update JSDoc examples if novel patterns emerged
@@ -124,18 +147,22 @@ Web Layer (Presentation)
 ## Quality Assurance Philosophy
 
 ### No Compromise Principle
-- **Technical Excellence First**: Quality is never negotiable, regardless of time pressure
+
+- **Technical Excellence First**: Quality is never negotiable, regardless of
+  time pressure
 - **Proper Solutions Only**: Address root causes, not symptoms
 - **Long-term Thinking**: Avoid technical debt that creates future problems
 - **Professional Standards**: Maintain enterprise-grade code quality
 
 ### When Facing Challenges
+
 1. **First Response**: Find the proper architectural solution
 2. **If Blocked**: Document the issue and seek guidance
 3. **Never Do**: Create temporary fixes, skip tests, or lower standards
 4. **Always Remember**: Clean code is faster to maintain and extend
 
 ### Quality Gates That Cannot Be Bypassed
+
 - Test coverage below 80% (hard block)
 - TypeScript compilation errors
 - ESLint violations (unless properly justified)
@@ -145,44 +172,54 @@ Web Layer (Presentation)
 ## Code Standards
 
 ### Architecture Rules
+
 - Domain layer has NO dependencies on other layers
 - Application layer depends only on Domain
 - Infrastructure implements Application ports
 - Web layer depends on Application ports only
 
 ### Testing Strategy
-- **Unit Tests**: Domain entities, value objects, use cases (Co-located .test.ts files)
+
+- **Unit Tests**: Domain entities, value objects, use cases (Co-located .test.ts
+  files)
 - **Integration Tests**: Database adapters, application services
 - **E2E Tests**: Complete user workflows
 - **Coverage**: 80% hard limit, 90% soft limit, 98% excellent
 - **TDD Required**: Write tests before implementation
 
 ### Code Quality
+
 - **TypeScript**: Strict mode, no `any` types
 - **ESLint**: Airbnb config with custom rules
 - **Prettier**: Consistent formatting
 - **Commits**: Conventional commits (feat:, fix:, test:, refactor:, docs:)
-- **No Compromise Policy**: 
+- **No Compromise Policy**:
   - No quick fixes or temporary solutions
   - No skipping tests to "save time"
   - No relaxing TypeScript strictness
   - No disabling ESLint rules without proper justification
 
 ### Documentation Standards (JSDoc Requirements)
-- **Class-level documentation**: Every class must have JSDoc explaining purpose and business context
-- **Method documentation**: Complex methods need examples and @remarks for non-obvious logic
+
+- **Class-level documentation**: Every class must have JSDoc explaining purpose
+  and business context
+- **Method documentation**: Complex methods need examples and @remarks for
+  non-obvious logic
 - **Domain terminology**: Explain softball-specific terms and business rules
-- **Validation rules**: Document not just "what" but "why" - the business reason behind constraints
+- **Validation rules**: Document not just "what" but "why" - the business reason
+  behind constraints
 
 ## Automated Review Process
 
 ### Review Timing
+
 - After general agent completes implementation tasks
 - Before any `git commit` attempt
 - After completing TodoWrite milestones
 - Before creating pull requests
 
 ### Review Workflow
+
 1. **Main Agent**: Triggers commit-readiness-reviewer
 2. **Reviewer**: Validates tests, coverage, architecture, documentation
 3. **Main Agent**: Summarizes feedback for user transparency
@@ -190,6 +227,7 @@ Web Layer (Presentation)
 5. **General-Purpose Agent**: Handles git operations when clean
 
 ### Review Feedback Display Pattern
+
 ```
 ✅ **Review Summary:**
 ✅ Tests: All tests passing
@@ -202,14 +240,18 @@ Web Layer (Presentation)
 ## Error Handling & Escalation
 
 ### Escalation Protocol
+
 When max attempts (3) exceeded:
+
 1. **Document Issue**: Capture specific error details and attempted solutions
 2. **Context Provision**: Show relevant error logs and affected files
 3. **User Notification**: Request guidance (no workarounds policy)
 4. **Clear Handoff**: Explain what was attempted and current state
 
 ### Quality-Related Escalations
+
 When facing quality vs. speed pressure:
+
 1. **Document the quality requirement** that seems challenging
 2. **Explain why the proper solution is important** for long-term success
 3. **Propose timeline adjustment** rather than quality compromise
@@ -218,17 +260,20 @@ When facing quality vs. speed pressure:
 ## Key Patterns
 
 ### Event Sourcing
+
 - All changes stored as events
 - Current state derived by replaying events
 - Perfect undo/redo support
 - Complete audit trail
 
 ### Dependency Injection
+
 - Ports defined in Application layer
 - Implementations in Infrastructure layer
 - Wired together in DI container
 
 ### Error Handling
+
 - Domain errors extend DomainError
 - Application errors handled at use case level
 - Infrastructure errors wrapped appropriately
@@ -248,4 +293,4 @@ When facing quality vs. speed pressure:
 
 ---
 
-*For current project progress and detailed task tracking, see TODO.local.md*
+_For current project progress and detailed task tracking, see TODO.local.md_

--- a/docs/design/event-sourcing.md
+++ b/docs/design/event-sourcing.md
@@ -1159,6 +1159,32 @@ describe('Game Event Sourcing', () => {
 
 ### Integration Testing
 
+Event sourcing integration tests validate cross-aggregate consistency and
+complete state reconstruction capabilities. The domain layer includes
+comprehensive integration tests in
+`packages/domain/src/integration/event-sourcing.test.ts`.
+
+#### Cross-Aggregate Integration Tests
+
+```typescript
+describe('Event Sourcing Cross-Aggregate Integration', () => {
+  it('should reconstruct full game state from mixed events', async () => {
+    // Tests complete state reconstruction across all three aggregates
+    // using event filtering patterns for aggregate-specific reconstruction
+  });
+
+  it('should maintain consistency across all three aggregates', async () => {
+    // Validates cross-aggregate consistency during event sourcing
+  });
+
+  it('should handle complex event sequences correctly', async () => {
+    // Tests event ordering and complex game scenarios
+  });
+});
+```
+
+#### Event Store Integration Tests (Future Phase 4.2)
+
 ```typescript
 describe('Event Store Integration', () => {
   let eventStore: IndexedDBEventStore;
@@ -1169,42 +1195,11 @@ describe('Event Store Integration', () => {
   });
 
   it('should persist and retrieve events correctly', async () => {
-    const gameId = new GameId('integration-test');
-    const events = [
-      new GameStarted(gameId, 'Home', 'Away', TeamSide.HOME),
-      new AtBatRecorded(
-        gameId,
-        new PlayerId('player1'),
-        AtBatResultType.SINGLE,
-        [],
-        0 /* ... */
-      ),
-    ];
-
-    // Persist events
-    await eventStore.append(gameId, events);
-
-    // Retrieve events
-    const storedEvents = await eventStore.getEvents(gameId);
-
-    expect(storedEvents).toHaveLength(2);
-    expect(storedEvents[0].eventType).toBe('GameStarted');
-    expect(storedEvents[1].eventType).toBe('AtBatRecorded');
+    // Event store persistence validation tests
   });
 
   it('should handle optimistic concurrency correctly', async () => {
-    const gameId = new GameId('concurrency-test');
-    const event1 = new GameStarted(gameId, 'Home', 'Away', TeamSide.HOME);
-
-    // First write
-    await eventStore.append(gameId, [event1], 0);
-
-    // Concurrent write with wrong expected version
-    const event2 = new AtBatRecorded(gameId /* ... */);
-
-    await expect(
-      eventStore.append(gameId, [event2], 0) // Wrong expected version
-    ).rejects.toThrow(OptimisticConcurrencyError);
+    // Concurrency conflict resolution tests
   });
 });
 ```

--- a/packages/domain/src/aggregates/Game.test.ts
+++ b/packages/domain/src/aggregates/Game.test.ts
@@ -1,6 +1,11 @@
 import { GameStatus } from '../constants/GameStatus';
 import { DomainError } from '../errors/DomainError';
+import { DomainEvent } from '../events/DomainEvent';
 import { GameCompleted } from '../events/GameCompleted';
+import { GameCreated } from '../events/GameCreated';
+import { GameStarted } from '../events/GameStarted';
+import { InningAdvanced } from '../events/InningAdvanced';
+import { ScoreUpdated } from '../events/ScoreUpdated';
 import { GameId } from '../value-objects/GameId';
 import { GameScore } from '../value-objects/GameScore';
 
@@ -464,6 +469,1055 @@ describe('Game Aggregate Root', () => {
         expect(event.gameId).toEqual(gameId);
         expect(event.type).toBeDefined();
         expect(typeof event.type).toBe('string');
+      });
+    });
+  });
+
+  describe('Game.applyEvent() - Event Application Logic', () => {
+    let gameId: GameId;
+
+    beforeEach(() => {
+      gameId = GameId.generate();
+    });
+
+    describe('GameStarted Event Application', () => {
+      it('should apply GameStarted event (status NOT_STARTED → IN_PROGRESS)', () => {
+        const gameStartedEvent = new GameStarted(gameId);
+        const events = [new GameCreated(gameId, 'Home Tigers', 'Away Lions'), gameStartedEvent];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.status).toBe(GameStatus.IN_PROGRESS);
+        expect(reconstructedGame.score).toEqual(GameScore.zero());
+        expect(reconstructedGame.currentInning).toBe(1);
+        expect(reconstructedGame.isTopHalf).toBe(true);
+        expect(reconstructedGame.outs).toBe(0);
+      });
+
+      it('should maintain other game state when applying GameStarted', () => {
+        const events = [new GameCreated(gameId, 'Springfield Tigers', 'Shelbyville Lions')];
+        const initialGame = Game.fromEvents(events);
+        expect(initialGame.status).toBe(GameStatus.NOT_STARTED);
+
+        // Apply GameStarted through fromEvents
+        const eventsWithStart = [...events, new GameStarted(gameId)];
+        const gameAfterStart = Game.fromEvents(eventsWithStart);
+
+        // Only status should change, all other properties preserved
+        expect(gameAfterStart.status).toBe(GameStatus.IN_PROGRESS);
+        expect(gameAfterStart.homeTeamName).toBe('Springfield Tigers');
+        expect(gameAfterStart.awayTeamName).toBe('Shelbyville Lions');
+        expect(gameAfterStart.score).toEqual(GameScore.zero());
+        expect(gameAfterStart.currentInning).toBe(1);
+        expect(gameAfterStart.isTopHalf).toBe(true);
+        expect(gameAfterStart.outs).toBe(0);
+      });
+    });
+
+    describe('ScoreUpdated Event Application', () => {
+      it('should apply ScoreUpdated event (update gameScore)', () => {
+        const scoreUpdateEvent = new ScoreUpdated(gameId, 'HOME', 3, { home: 3, away: 0 });
+        const events = [new GameCreated(gameId, 'Home Tigers', 'Away Lions'), scoreUpdateEvent];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.score.getHomeRuns()).toBe(3);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(0);
+        expect(reconstructedGame.status).toBe(GameStatus.NOT_STARTED); // Only score changed
+      });
+
+      it('should update to final score from ScoreUpdated event', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 2, { home: 2, away: 0 }),
+          new ScoreUpdated(gameId, 'AWAY', 5, { home: 2, away: 5 }),
+          new ScoreUpdated(gameId, 'HOME', 3, { home: 5, away: 5 }),
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        // Should have the final score from the last ScoreUpdated event
+        expect(reconstructedGame.score.getHomeRuns()).toBe(5);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(5);
+        expect(reconstructedGame.score.isTied()).toBe(true);
+      });
+
+      it('should handle multiple consecutive score updates', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+          new ScoreUpdated(gameId, 'HOME', 2, { home: 3, away: 0 }),
+          new ScoreUpdated(gameId, 'AWAY', 1, { home: 3, away: 1 }),
+          new ScoreUpdated(gameId, 'AWAY', 2, { home: 3, away: 3 }),
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.score.getHomeRuns()).toBe(3);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(3);
+      });
+    });
+
+    describe('InningAdvanced Event Application', () => {
+      it('should apply InningAdvanced event (inning and half)', () => {
+        const inningAdvancedEvent = new InningAdvanced(gameId, 2, false); // Bottom of 2nd
+        const events = [new GameCreated(gameId, 'Home Tigers', 'Away Lions'), inningAdvancedEvent];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.currentInning).toBe(2);
+        expect(reconstructedGame.isTopHalf).toBe(false);
+        expect(reconstructedGame.outs).toBe(0); // Outs reset when inning advances
+      });
+
+      it('should reset outs to 0 when applying InningAdvanced', () => {
+        // Create a scenario where we know outs would be reset
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new InningAdvanced(gameId, 1, false), // Bottom of 1st, outs = 0
+          new InningAdvanced(gameId, 2, true), // Top of 2nd, outs = 0
+          new InningAdvanced(gameId, 2, false), // Bottom of 2nd, outs = 0
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.currentInning).toBe(2);
+        expect(reconstructedGame.isTopHalf).toBe(false);
+        expect(reconstructedGame.outs).toBe(0);
+      });
+
+      it('should handle inning progression through multiple advances', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new InningAdvanced(gameId, 1, false), // Bottom 1st
+          new InningAdvanced(gameId, 2, true), // Top 2nd
+          new InningAdvanced(gameId, 2, false), // Bottom 2nd
+          new InningAdvanced(gameId, 3, true), // Top 3rd
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.currentInning).toBe(3);
+        expect(reconstructedGame.isTopHalf).toBe(true);
+        expect(reconstructedGame.outs).toBe(0);
+      });
+
+      it('should maintain game state except inning/outs when applying InningAdvanced', () => {
+        const events = [
+          new GameCreated(gameId, 'Nuclear Plant', 'Capital City'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 7, { home: 7, away: 0 }),
+          new InningAdvanced(gameId, 5, true), // Jump to 5th inning
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        // Score and other state preserved
+        expect(reconstructedGame.status).toBe(GameStatus.IN_PROGRESS);
+        expect(reconstructedGame.score.getHomeRuns()).toBe(7);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(0);
+        expect(reconstructedGame.homeTeamName).toBe('Nuclear Plant');
+        expect(reconstructedGame.awayTeamName).toBe('Capital City');
+        // Only inning and outs should change
+        expect(reconstructedGame.currentInning).toBe(5);
+        expect(reconstructedGame.isTopHalf).toBe(true);
+        expect(reconstructedGame.outs).toBe(0);
+      });
+    });
+
+    describe('GameCompleted Event Application', () => {
+      it('should apply GameCompleted event (status → COMPLETED)', () => {
+        const gameCompletedEvent = new GameCompleted(gameId, 'REGULATION', { home: 8, away: 5 }, 7);
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          gameCompletedEvent,
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.status).toBe(GameStatus.COMPLETED);
+        expect(reconstructedGame.score.getHomeRuns()).toBe(8);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(5);
+      });
+
+      it('should update score to final score from GameCompleted event', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 5, { home: 5, away: 0 }), // Intermediate score
+          new GameCompleted(gameId, 'MERCY_RULE', { home: 15, away: 2 }, 5), // Final score
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        // Final score should come from GameCompleted event
+        expect(reconstructedGame.status).toBe(GameStatus.COMPLETED);
+        expect(reconstructedGame.score.getHomeRuns()).toBe(15);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(2);
+      });
+
+      it('should handle different completion types', () => {
+        const completionTypes: Array<'REGULATION' | 'MERCY_RULE' | 'FORFEIT' | 'TIME_LIMIT'> = [
+          'REGULATION',
+          'MERCY_RULE',
+          'FORFEIT',
+          'TIME_LIMIT',
+        ];
+
+        completionTypes.forEach(endingType => {
+          const testGameId = GameId.generate();
+          const events = [
+            new GameCreated(testGameId, 'Team A', 'Team B'),
+            new GameStarted(testGameId),
+            new GameCompleted(testGameId, endingType, { home: 6, away: 3 }, 7),
+          ];
+
+          const reconstructedGame = Game.fromEvents(events);
+
+          expect(reconstructedGame.status).toBe(GameStatus.COMPLETED);
+          expect(reconstructedGame.score.getHomeRuns()).toBe(6);
+          expect(reconstructedGame.score.getAwayRuns()).toBe(3);
+        });
+      });
+    });
+
+    describe('Unknown Event Types', () => {
+      it('should throw error for unknown event types gracefully', () => {
+        // Create a mock unknown event
+        const unknownEvent = {
+          type: 'UnknownEventType',
+          gameId,
+          timestamp: new Date(),
+          eventId: 'test-event-id',
+        } as unknown as DomainEvent;
+
+        const events = [new GameCreated(gameId, 'Home Tigers', 'Away Lions'), unknownEvent];
+
+        expect(() => Game.fromEvents(events)).toThrow(DomainError);
+        expect(() => Game.fromEvents(events)).toThrow(
+          'Unsupported event type for reconstruction: UnknownEventType'
+        );
+      });
+
+      it('should throw error with descriptive message for unsupported events', () => {
+        const unsupportedEvent = {
+          type: 'FutureEventType',
+          gameId,
+          timestamp: new Date(),
+          eventId: 'future-event-123',
+        } as unknown as DomainEvent;
+
+        const events = [new GameCreated(gameId, 'Home Tigers', 'Away Lions'), unsupportedEvent];
+
+        expect(() => Game.fromEvents(events)).toThrow(
+          'Unsupported event type for reconstruction: FutureEventType'
+        );
+      });
+    });
+
+    describe('Event Application Idempotency and Robustness', () => {
+      it('should be idempotent (same event applied twice = no change)', () => {
+        // Create a game state, then apply the same event sequence twice
+        const baseEvents = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 3, { home: 3, away: 0 }),
+          new InningAdvanced(gameId, 1, false),
+        ];
+
+        const game1 = Game.fromEvents(baseEvents);
+        const game2 = Game.fromEvents(baseEvents); // Apply same events again
+
+        // Both games should have identical state
+        expect(game1.status).toBe(game2.status);
+        expect(game1.score.getHomeRuns()).toBe(game2.score.getHomeRuns());
+        expect(game1.score.getAwayRuns()).toBe(game2.score.getAwayRuns());
+        expect(game1.currentInning).toBe(game2.currentInning);
+        expect(game1.isTopHalf).toBe(game2.isTopHalf);
+        expect(game1.outs).toBe(game2.outs);
+        expect(game1.homeTeamName).toBe(game2.homeTeamName);
+        expect(game1.awayTeamName).toBe(game2.awayTeamName);
+      });
+
+      it('should handle events with matching game ID', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId), // Same game ID
+          new ScoreUpdated(gameId, 'HOME', 2, { home: 2, away: 0 }), // Same game ID
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.id).toEqual(gameId);
+        expect(reconstructedGame.status).toBe(GameStatus.IN_PROGRESS);
+        expect(reconstructedGame.score.getHomeRuns()).toBe(2);
+      });
+
+      it('should maintain domain invariants after applying events', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 10, { home: 10, away: 0 }),
+          new ScoreUpdated(gameId, 'AWAY', 7, { home: 10, away: 7 }),
+          new InningAdvanced(gameId, 5, true),
+          new InningAdvanced(gameId, 5, false),
+          new GameCompleted(gameId, 'REGULATION', { home: 12, away: 8 }, 7),
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        // Verify all domain invariants maintained
+        expect(reconstructedGame.score.getHomeRuns()).toBeGreaterThanOrEqual(0);
+        expect(reconstructedGame.score.getAwayRuns()).toBeGreaterThanOrEqual(0);
+        expect(reconstructedGame.currentInning).toBeGreaterThan(0);
+        expect(reconstructedGame.outs).toBeGreaterThanOrEqual(0);
+        expect(reconstructedGame.outs).toBeLessThan(3); // Outs reset to 0 with advances
+        expect(reconstructedGame.homeTeamName).toBeTruthy();
+        expect(reconstructedGame.awayTeamName).toBeTruthy();
+        expect(reconstructedGame.homeTeamName).not.toBe(reconstructedGame.awayTeamName);
+      });
+
+      it('should not affect uncommitted events array during reconstruction', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        // Reconstructed game should have no uncommitted events
+        expect(reconstructedGame.getUncommittedEvents()).toHaveLength(0);
+      });
+
+      it('should handle sparse event arrays during reconstruction', () => {
+        // The null check in fromEvents() line 500 is defensive programming for sparse arrays
+        // This test verifies the method can handle normal event reconstruction properly
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        // Should successfully reconstruct all events
+        expect(reconstructedGame.status).toBe(GameStatus.IN_PROGRESS);
+        expect(reconstructedGame.score.getHomeRuns()).toBe(1);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(0);
+      });
+
+      it('should validate event belongs to the game during reconstruction', () => {
+        const differentGameId = GameId.generate();
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(differentGameId), // Wrong game ID
+        ];
+
+        expect(() => Game.fromEvents(events)).toThrow(DomainError);
+        expect(() => Game.fromEvents(events)).toThrow('All events must belong to the same game');
+      });
+    });
+
+    describe('Complex Event Application Scenarios', () => {
+      it('should handle rapid status transitions', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId), // NOT_STARTED -> IN_PROGRESS
+          new GameCompleted(gameId, 'FORFEIT', { home: 0, away: 0 }, 1), // IN_PROGRESS -> COMPLETED
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.status).toBe(GameStatus.COMPLETED);
+        expect(reconstructedGame.score.getHomeRuns()).toBe(0);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(0);
+      });
+
+      it('should maintain event ordering integrity', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new InningAdvanced(gameId, 1, false), // Bottom 1st
+          new ScoreUpdated(gameId, 'HOME', 5, { home: 5, away: 0 }),
+          new InningAdvanced(gameId, 2, true), // Top 2nd
+          new ScoreUpdated(gameId, 'AWAY', 3, { home: 5, away: 3 }),
+          new InningAdvanced(gameId, 2, false), // Bottom 2nd
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.status).toBe(GameStatus.IN_PROGRESS);
+        expect(reconstructedGame.currentInning).toBe(2);
+        expect(reconstructedGame.isTopHalf).toBe(false);
+        expect(reconstructedGame.score.getHomeRuns()).toBe(5);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(3);
+        expect(reconstructedGame.outs).toBe(0);
+      });
+
+      it('should reconstruct final game state correctly from complete event stream', () => {
+        const events = [
+          new GameCreated(gameId, 'Springfield Tigers', 'Capital City Goofballs'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 2, { home: 2, away: 0 }),
+          new InningAdvanced(gameId, 1, false), // Bottom 1st
+          new ScoreUpdated(gameId, 'AWAY', 1, { home: 2, away: 1 }),
+          new InningAdvanced(gameId, 2, true), // Top 2nd
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 3, away: 1 }),
+          new InningAdvanced(gameId, 2, false), // Bottom 2nd
+          new InningAdvanced(gameId, 3, true), // Top 3rd
+          new InningAdvanced(gameId, 3, false), // Bottom 3rd
+          new InningAdvanced(gameId, 4, true), // Top 4th
+          new InningAdvanced(gameId, 4, false), // Bottom 4th
+          new InningAdvanced(gameId, 5, true), // Top 5th
+          new InningAdvanced(gameId, 5, false), // Bottom 5th
+          new InningAdvanced(gameId, 6, true), // Top 6th
+          new InningAdvanced(gameId, 6, false), // Bottom 6th
+          new InningAdvanced(gameId, 7, true), // Top 7th
+          new ScoreUpdated(gameId, 'AWAY', 2, { home: 3, away: 3 }),
+          new InningAdvanced(gameId, 7, false), // Bottom 7th
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 4, away: 3 }), // Walk-off
+          new GameCompleted(gameId, 'REGULATION', { home: 4, away: 3 }, 7),
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.homeTeamName).toBe('Springfield Tigers');
+        expect(reconstructedGame.awayTeamName).toBe('Capital City Goofballs');
+        expect(reconstructedGame.status).toBe(GameStatus.COMPLETED);
+        expect(reconstructedGame.score.getHomeRuns()).toBe(4);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(3);
+        expect(reconstructedGame.currentInning).toBe(7);
+        expect(reconstructedGame.isTopHalf).toBe(false);
+        expect(reconstructedGame.outs).toBe(0);
+      });
+    });
+  });
+
+  describe('Game Event Management', () => {
+    let gameId: GameId;
+    let game: Game;
+
+    beforeEach(() => {
+      gameId = GameId.generate();
+      game = Game.createNew(gameId, 'Home Tigers', 'Away Lions');
+    });
+
+    describe('getUncommittedEvents()', () => {
+      it('should return copy of uncommittedEvents array', () => {
+        const uncommittedEvents = game.getUncommittedEvents();
+
+        // Should return array with initial GameCreated event
+        expect(uncommittedEvents).toHaveLength(1);
+        expect(uncommittedEvents[0]?.type).toBe('GameCreated');
+
+        // Should return a copy, not the original array
+        uncommittedEvents.push({} as DomainEvent);
+        expect(game.getUncommittedEvents()).toHaveLength(1); // Original should be unchanged
+      });
+
+      it('should start with empty uncommitted events after markEventsAsCommitted()', () => {
+        game.markEventsAsCommitted();
+
+        expect(game.getUncommittedEvents()).toHaveLength(0);
+      });
+
+      it('should add events to uncommitted events when domain operations occur', () => {
+        game.markEventsAsCommitted(); // Clear creation event
+
+        game.startGame();
+        expect(game.getUncommittedEvents()).toHaveLength(1);
+        expect(game.getUncommittedEvents()[0]?.type).toBe('GameStarted');
+
+        game.addHomeRuns(2);
+        expect(game.getUncommittedEvents()).toHaveLength(2);
+        expect(game.getUncommittedEvents()[1]?.type).toBe('ScoreUpdated');
+
+        game.advanceInning();
+        expect(game.getUncommittedEvents()).toHaveLength(3);
+        expect(game.getUncommittedEvents()[2]?.type).toBe('InningAdvanced');
+      });
+
+      it('should maintain uncommitted events immutability (return copy, not reference)', () => {
+        const uncommittedEvents1 = game.getUncommittedEvents();
+        const uncommittedEvents2 = game.getUncommittedEvents();
+
+        // Should be different array instances
+        expect(uncommittedEvents1).not.toBe(uncommittedEvents2);
+
+        // But should have same content
+        expect(uncommittedEvents1).toEqual(uncommittedEvents2);
+
+        // Modifying one should not affect the other
+        uncommittedEvents1[0] = {} as DomainEvent;
+        expect(uncommittedEvents2[0]?.type).toBe('GameCreated');
+      });
+    });
+
+    describe('markEventsAsCommitted()', () => {
+      it('should clear uncommittedEvents array', () => {
+        game.startGame();
+        game.addHomeRuns(1);
+        expect(game.getUncommittedEvents()).toHaveLength(3); // GameCreated + GameStarted + ScoreUpdated
+
+        game.markEventsAsCommitted();
+
+        expect(game.getUncommittedEvents()).toHaveLength(0);
+      });
+
+      it('should not affect game state when clearing events', () => {
+        game.startGame();
+        game.addHomeRuns(3);
+        game.advanceInning();
+
+        const originalStatus = game.status;
+        const originalScore = game.score;
+        const originalInning = game.currentInning;
+        const originalIsTopHalf = game.isTopHalf;
+
+        game.markEventsAsCommitted();
+
+        // State should remain unchanged
+        expect(game.status).toBe(originalStatus);
+        expect(game.score).toEqual(originalScore);
+        expect(game.currentInning).toBe(originalInning);
+        expect(game.isTopHalf).toBe(originalIsTopHalf);
+      });
+
+      it('should allow new events to be added after clearing', () => {
+        game.startGame();
+        game.markEventsAsCommitted();
+        expect(game.getUncommittedEvents()).toHaveLength(0);
+
+        game.addAwayRuns(2);
+        expect(game.getUncommittedEvents()).toHaveLength(1);
+        expect(game.getUncommittedEvents()[0]?.type).toBe('ScoreUpdated');
+      });
+    });
+
+    describe('getVersion()', () => {
+      it('should return current event stream version', () => {
+        // Game should have version 1 after creation (GameCreated event)
+        expect(game.getVersion()).toBe(1);
+      });
+
+      it('should start with version 1 after creation (GameCreated event)', () => {
+        // Game starts with version 1 after GameCreated event
+        expect(game.getVersion()).toBe(1);
+      });
+
+      it('should increment version when events are added', () => {
+        expect(game.getVersion()).toBe(1); // Initial: GameCreated
+
+        game.startGame(); // Version should be 2
+        expect(game.getVersion()).toBe(2);
+
+        game.addHomeRuns(1); // Version should be 3
+        expect(game.getVersion()).toBe(3);
+
+        game.advanceInning(); // Version should be 4
+        expect(game.getVersion()).toBe(4);
+      });
+
+      it('should maintain version after events are marked as committed', () => {
+        game.startGame();
+        game.addHomeRuns(2);
+        const versionBeforeCommit = game.getVersion(); // Should be 3
+
+        game.markEventsAsCommitted();
+        expect(game.getVersion()).toBe(versionBeforeCommit); // Version should persist
+      });
+
+      it('should maintain version after reconstruction from events', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 2, { home: 2, away: 0 }),
+          new InningAdvanced(gameId, 1, false),
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        expect(reconstructedGame.getVersion()).toBe(4); // Should match event count
+      });
+    });
+
+    describe('Version tracking across operations', () => {
+      it('should track version correctly across multiple operations', () => {
+        // Test progression through multiple operations
+        expect(game.getVersion()).toBe(1); // Initial: GameCreated
+        game.startGame();
+        expect(game.getVersion()).toBe(2); // + GameStarted
+        game.addHomeRuns(3);
+        expect(game.getVersion()).toBe(3); // + ScoreUpdated
+        game.advanceInning();
+        expect(game.getVersion()).toBe(4); // + InningAdvanced
+        game.addAwayRuns(1);
+        expect(game.getVersion()).toBe(5); // + ScoreUpdated
+        game.advanceInning();
+        expect(game.getVersion()).toBe(6); // + InningAdvanced
+        game.completeGame('REGULATION');
+        expect(game.getVersion()).toBe(7); // + GameCompleted
+      });
+
+      it('should handle version correctly after events are marked as committed', () => {
+        game.startGame();
+        game.addHomeRuns(2);
+        game.advanceInning();
+
+        const versionBeforeCommit = game.getVersion(); // Should be 4
+        game.markEventsAsCommitted();
+        expect(game.getVersion()).toBe(versionBeforeCommit); // Version should remain
+        expect(game.getUncommittedEvents()).toHaveLength(0); // But events should be cleared
+
+        // Add new events and verify version continues incrementing
+        game.addAwayRuns(1);
+        expect(game.getVersion()).toBe(versionBeforeCommit + 1); // Should increment from previous version
+      });
+
+      it('should start with version 1 for new games after GameCreated event', () => {
+        // After Game.createNew(), version should be 1 (GameCreated event)
+        expect(game.getVersion()).toBe(1);
+      });
+    });
+
+    describe('Event management integration with repository operations', () => {
+      it('should support typical repository save pattern', () => {
+        // Simulate repository save pattern
+        game.startGame();
+        game.addHomeRuns(3);
+
+        // Repository would get uncommitted events
+        const eventsToSave = game.getUncommittedEvents();
+        expect(eventsToSave).toHaveLength(3); // GameCreated + GameStarted + ScoreUpdated
+
+        // After successful save, repository would mark as committed
+        game.markEventsAsCommitted();
+        expect(game.getUncommittedEvents()).toHaveLength(0);
+      });
+
+      it('should support event sourcing reconstruction pattern', () => {
+        // Simulate what repository would do to reconstruct aggregate
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 5, { home: 5, away: 0 }),
+          new InningAdvanced(gameId, 1, false),
+          new ScoreUpdated(gameId, 'AWAY', 2, { home: 5, away: 2 }),
+        ];
+
+        const reconstructedGame = Game.fromEvents(events);
+
+        // Reconstructed game should have correct state
+        expect(reconstructedGame.status).toBe(GameStatus.IN_PROGRESS);
+        expect(reconstructedGame.score.getHomeRuns()).toBe(5);
+        expect(reconstructedGame.score.getAwayRuns()).toBe(2);
+        expect(reconstructedGame.currentInning).toBe(1);
+        expect(reconstructedGame.isTopHalf).toBe(false);
+
+        // Should have no uncommitted events (all events are from committed stream)
+        expect(reconstructedGame.getUncommittedEvents()).toHaveLength(0);
+      });
+
+      it('should handle mixed committed and new events correctly', () => {
+        // Start with reconstructed game (all events committed)
+        const committedEvents = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 2, { home: 2, away: 0 }),
+        ];
+
+        const reconstructedGame = Game.fromEvents(committedEvents);
+        expect(reconstructedGame.getUncommittedEvents()).toHaveLength(0);
+
+        // Add new operations (should create new uncommitted events)
+        reconstructedGame.advanceInning();
+        reconstructedGame.addAwayRuns(1);
+
+        const newUncommittedEvents = reconstructedGame.getUncommittedEvents();
+        expect(newUncommittedEvents).toHaveLength(2);
+        expect(newUncommittedEvents[0]?.type).toBe('InningAdvanced');
+        expect(newUncommittedEvents[1]?.type).toBe('ScoreUpdated');
+      });
+
+      it('should maintain data integrity between uncommitted events and current state', () => {
+        game.startGame();
+        game.addHomeRuns(4);
+        game.advanceInning();
+        game.addAwayRuns(2);
+
+        const uncommittedEvents = game.getUncommittedEvents();
+
+        // Verify events match current state
+        const createdEvent = uncommittedEvents.find(e => e.type === 'GameCreated') as GameCreated;
+        expect(createdEvent?.homeTeamName).toBe(game.homeTeamName);
+        expect(createdEvent?.awayTeamName).toBe(game.awayTeamName);
+
+        const scoreEvents = uncommittedEvents.filter(
+          e => e.type === 'ScoreUpdated'
+        ) as ScoreUpdated[];
+        const latestScoreEvent = scoreEvents[scoreEvents.length - 1];
+        if (latestScoreEvent) {
+          expect(latestScoreEvent.newScore.home).toBe(game.score.getHomeRuns());
+          expect(latestScoreEvent.newScore.away).toBe(game.score.getAwayRuns());
+        }
+
+        const inningEvent = uncommittedEvents.find(
+          e => e.type === 'InningAdvanced'
+        ) as InningAdvanced;
+        if (inningEvent) {
+          expect(inningEvent.newInning).toBe(game.currentInning);
+          expect(inningEvent.isTopHalf).toBe(game.isTopHalf);
+        }
+      });
+    });
+  });
+
+  describe('Game.fromEvents() - Event Sourcing Reconstruction', () => {
+    let gameId: GameId;
+    let baseEvents: DomainEvent[];
+
+    beforeEach(() => {
+      gameId = GameId.generate();
+      // Base events for most tests: creation and start
+      baseEvents = [new GameCreated(gameId, 'Home Tigers', 'Away Lions'), new GameStarted(gameId)];
+    });
+
+    describe('Basic Reconstruction', () => {
+      it('should create game from GameCreated event', () => {
+        const events = [new GameCreated(gameId, 'Home Tigers', 'Away Lions')];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.id).toEqual(gameId);
+        expect(game.homeTeamName).toBe('Home Tigers');
+        expect(game.awayTeamName).toBe('Away Lions');
+        expect(game.status).toBe(GameStatus.NOT_STARTED);
+        expect(game.score).toEqual(GameScore.zero());
+        expect(game.currentInning).toBe(1);
+        expect(game.isTopHalf).toBe(true);
+        expect(game.outs).toBe(0);
+        expect(game.getUncommittedEvents()).toHaveLength(0); // Events are already committed
+      });
+
+      it('should replay events in chronological order', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 2, { home: 2, away: 0 }),
+          new InningAdvanced(gameId, 1, false), // Bottom of 1st
+          new ScoreUpdated(gameId, 'AWAY', 1, { home: 2, away: 1 }),
+          new InningAdvanced(gameId, 2, true), // Top of 2nd
+        ];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.status).toBe(GameStatus.IN_PROGRESS);
+        expect(game.score.getHomeRuns()).toBe(2);
+        expect(game.score.getAwayRuns()).toBe(1);
+        expect(game.currentInning).toBe(2);
+        expect(game.isTopHalf).toBe(true);
+        expect(game.outs).toBe(0);
+      });
+
+      it('should maintain domain invariants during reconstruction', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 5, { home: 5, away: 0 }),
+          new ScoreUpdated(gameId, 'AWAY', 3, { home: 5, away: 3 }),
+          new GameCompleted(gameId, 'REGULATION', { home: 5, away: 3 }, 7),
+        ];
+
+        const game = Game.fromEvents(events);
+
+        // Game should maintain all invariants
+        expect(game.status).toBe(GameStatus.COMPLETED);
+        expect(game.score.getHomeRuns()).toBeGreaterThanOrEqual(0);
+        expect(game.score.getAwayRuns()).toBeGreaterThanOrEqual(0);
+        expect(game.currentInning).toBeGreaterThan(0);
+        expect(game.outs).toBeGreaterThanOrEqual(0);
+        expect(game.outs).toBeLessThan(3);
+        expect(game.homeTeamName).toBeTruthy();
+        expect(game.awayTeamName).toBeTruthy();
+        expect(game.homeTeamName).not.toBe(game.awayTeamName);
+      });
+    });
+
+    describe('Error Scenarios', () => {
+      it('should handle empty event array gracefully', () => {
+        const events: DomainEvent[] = [];
+
+        expect(() => Game.fromEvents(events)).toThrow(DomainError);
+        expect(() => Game.fromEvents(events)).toThrow(
+          'Cannot reconstruct game from empty event array'
+        );
+      });
+
+      it('should throw error if first event is not GameCreated', () => {
+        const events = [
+          new GameStarted(gameId), // Missing GameCreated as first event
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+        ];
+
+        expect(() => Game.fromEvents(events)).toThrow(DomainError);
+        expect(() => Game.fromEvents(events)).toThrow('First event must be GameCreated');
+      });
+
+      it('should throw error for events with different game IDs', () => {
+        const anotherGameId = GameId.generate();
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(anotherGameId), // Different game ID
+        ];
+
+        expect(() => Game.fromEvents(events)).toThrow(DomainError);
+        expect(() => Game.fromEvents(events)).toThrow('All events must belong to the same game');
+      });
+
+      it('should throw error for null or undefined events array', () => {
+        expect(() => Game.fromEvents(null as unknown as DomainEvent[])).toThrow(DomainError);
+        expect(() => Game.fromEvents(undefined as unknown as DomainEvent[])).toThrow(DomainError);
+      });
+    });
+
+    describe('Complex Game Scenarios', () => {
+      it('should reconstruct complete regulation game', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 3, { home: 3, away: 0 }),
+          new InningAdvanced(gameId, 1, false), // Bottom 1st
+          new ScoreUpdated(gameId, 'AWAY', 2, { home: 3, away: 2 }),
+          new InningAdvanced(gameId, 2, true), // Top 2nd
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 4, away: 2 }),
+          new InningAdvanced(gameId, 2, false), // Bottom 2nd
+          new InningAdvanced(gameId, 3, true), // Top 3rd
+          // ... continue through 7 innings
+          new GameCompleted(gameId, 'REGULATION', { home: 8, away: 6 }, 7),
+        ];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.status).toBe(GameStatus.COMPLETED);
+        expect(game.score.getHomeRuns()).toBe(8);
+        expect(game.score.getAwayRuns()).toBe(6);
+      });
+
+      it('should reconstruct mercy rule game', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 15, { home: 15, away: 0 }),
+          new InningAdvanced(gameId, 1, false), // Bottom 1st
+          new InningAdvanced(gameId, 2, true), // Top 2nd
+          new InningAdvanced(gameId, 2, false), // Bottom 2nd
+          new InningAdvanced(gameId, 3, true), // Top 3rd
+          new InningAdvanced(gameId, 3, false), // Bottom 3rd
+          new InningAdvanced(gameId, 4, true), // Top 4th
+          new InningAdvanced(gameId, 4, false), // Bottom 4th
+          new InningAdvanced(gameId, 5, true), // Top 5th (mercy rule eligible)
+          new GameCompleted(gameId, 'MERCY_RULE', { home: 15, away: 0 }, 5),
+        ];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.status).toBe(GameStatus.COMPLETED);
+        expect(game.score.getHomeRuns()).toBe(15);
+        expect(game.score.getAwayRuns()).toBe(0);
+        expect(game.currentInning).toBe(5);
+        expect(game.isMercyRuleTriggered()).toBe(true);
+      });
+
+      it('should reconstruct game with multiple score updates', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+          new ScoreUpdated(gameId, 'HOME', 2, { home: 3, away: 0 }),
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 4, away: 0 }),
+          new InningAdvanced(gameId, 1, false),
+          new ScoreUpdated(gameId, 'AWAY', 2, { home: 4, away: 2 }),
+          new ScoreUpdated(gameId, 'AWAY', 1, { home: 4, away: 3 }),
+        ];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.status).toBe(GameStatus.IN_PROGRESS);
+        expect(game.score.getHomeRuns()).toBe(4);
+        expect(game.score.getAwayRuns()).toBe(3);
+        expect(game.currentInning).toBe(1);
+        expect(game.isTopHalf).toBe(false);
+      });
+
+      it('should reconstruct extra innings game', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          // Simulate 7 innings with tied score
+          new ScoreUpdated(gameId, 'HOME', 5, { home: 5, away: 0 }),
+          new InningAdvanced(gameId, 1, false),
+          new ScoreUpdated(gameId, 'AWAY', 5, { home: 5, away: 5 }),
+          // Fast forward through innings (simplified for test)
+          new InningAdvanced(gameId, 8, true), // Extra innings
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 6, away: 5 }),
+          new InningAdvanced(gameId, 8, false),
+          new GameCompleted(gameId, 'REGULATION', { home: 6, away: 5 }, 8),
+        ];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.status).toBe(GameStatus.COMPLETED);
+        expect(game.score.getHomeRuns()).toBe(6);
+        expect(game.score.getAwayRuns()).toBe(5);
+        expect(game.currentInning).toBe(8); // Extra innings
+      });
+    });
+
+    describe('Event Stream Validation', () => {
+      it('should validate all events belong to same game', () => {
+        const anotherGameId = GameId.generate();
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(anotherGameId, 'HOME', 1, { home: 1, away: 0 }), // Wrong game
+        ];
+
+        expect(() => Game.fromEvents(events)).toThrow(DomainError);
+        expect(() => Game.fromEvents(events)).toThrow('All events must belong to the same game');
+      });
+
+      it('should handle events in chronological order by timestamp', () => {
+        // Create events with specific timestamps to test ordering
+        const event1 = new GameCreated(gameId, 'Home Tigers', 'Away Lions');
+        const event2 = new GameStarted(gameId);
+        const event3 = new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 });
+
+        // Manually set timestamps (in real scenarios, this would be natural)
+        const now = new Date();
+        Object.defineProperty(event1, 'timestamp', {
+          value: new Date(now.getTime() - 2000),
+          writable: false,
+        });
+        Object.defineProperty(event2, 'timestamp', {
+          value: new Date(now.getTime() - 1000),
+          writable: false,
+        });
+        Object.defineProperty(event3, 'timestamp', {
+          value: now,
+          writable: false,
+        });
+
+        const events = [event1, event2, event3];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.status).toBe(GameStatus.IN_PROGRESS);
+        expect(game.score.getHomeRuns()).toBe(1);
+      });
+
+      it('should handle duplicate game creation event gracefully', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'), // Duplicate
+        ];
+
+        // Should either ignore duplicate or throw meaningful error
+        expect(() => Game.fromEvents(events)).toThrow(DomainError);
+      });
+    });
+
+    describe('State Consistency', () => {
+      it('should maintain score consistency across multiple updates', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 2, { home: 2, away: 0 }),
+          new ScoreUpdated(gameId, 'AWAY', 3, { home: 2, away: 3 }),
+          new ScoreUpdated(gameId, 'HOME', 1, { home: 3, away: 3 }),
+        ];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.score.getHomeRuns()).toBe(3);
+        expect(game.score.getAwayRuns()).toBe(3);
+        expect(game.score.isTied()).toBe(true);
+      });
+
+      it('should maintain inning progression consistency', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+          new InningAdvanced(gameId, 1, false), // Bottom 1st
+          new InningAdvanced(gameId, 2, true), // Top 2nd
+          new InningAdvanced(gameId, 2, false), // Bottom 2nd
+          new InningAdvanced(gameId, 3, true), // Top 3rd
+        ];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.currentInning).toBe(3);
+        expect(game.isTopHalf).toBe(true);
+        expect(game.outs).toBe(0); // Outs reset with inning advancement
+      });
+
+      it('should preserve team names throughout event stream', () => {
+        const homeTeam = 'Springfield Nuclear Plant Workers';
+        const awayTeam = 'Capital City Goofballs';
+
+        const events = [
+          new GameCreated(gameId, homeTeam, awayTeam),
+          new GameStarted(gameId),
+          new ScoreUpdated(gameId, 'HOME', 10, { home: 10, away: 0 }),
+          new InningAdvanced(gameId, 5, true),
+          new GameCompleted(gameId, 'MERCY_RULE', { home: 15, away: 2 }, 5),
+        ];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.homeTeamName).toBe(homeTeam);
+        expect(game.awayTeamName).toBe(awayTeam);
+        expect(game.status).toBe(GameStatus.COMPLETED);
+      });
+    });
+
+    describe('Performance and Edge Cases', () => {
+      it('should handle empty uncommitted events after reconstruction', () => {
+        const events = baseEvents;
+
+        const game = Game.fromEvents(events);
+
+        expect(game.getUncommittedEvents()).toHaveLength(0);
+        expect(game.status).toBe(GameStatus.IN_PROGRESS);
+      });
+
+      it('should handle single GameCreated event', () => {
+        const events = [new GameCreated(gameId, 'Home', 'Away')];
+
+        const game = Game.fromEvents(events);
+
+        expect(game.status).toBe(GameStatus.NOT_STARTED);
+        expect(game.homeTeamName).toBe('Home');
+        expect(game.awayTeamName).toBe('Away');
+        expect(game.score.isZero()).toBe(true);
+      });
+
+      it('should maintain immutability of reconstructed game', () => {
+        const events = [
+          new GameCreated(gameId, 'Home Tigers', 'Away Lions'),
+          new GameStarted(gameId),
+        ];
+
+        const game = Game.fromEvents(events);
+        const originalScore = game.score;
+        const originalStatus = game.status;
+
+        // Game properties should be immutable from external access
+        expect(game.score).toBe(originalScore);
+        expect(game.status).toBe(originalStatus);
+        expect(game.id).toEqual(gameId);
       });
     });
   });

--- a/packages/domain/src/aggregates/InningState.test.ts
+++ b/packages/domain/src/aggregates/InningState.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect } from 'vitest';
 
 import { AtBatResultType } from '../constants/AtBatResultType';
 import { DomainError } from '../errors/DomainError';
+import { AtBatCompleted } from '../events/AtBatCompleted';
+import { CurrentBatterChanged } from '../events/CurrentBatterChanged';
+import { DomainEvent } from '../events/DomainEvent';
+import { HalfInningEnded } from '../events/HalfInningEnded';
+import { InningAdvanced } from '../events/InningAdvanced';
+import { InningStateCreated } from '../events/InningStateCreated';
+import { RunnerAdvanced, AdvanceReason } from '../events/RunnerAdvanced';
+import { RunScored } from '../events/RunScored';
 import { GameId } from '../value-objects/GameId';
 import { InningStateId } from '../value-objects/InningStateId';
 import { PlayerId } from '../value-objects/PlayerId';
@@ -773,6 +781,754 @@ describe('InningState', () => {
 
       // Should not crash and return updated state
       expect(updated).toBeDefined();
+    });
+  });
+
+  describe('InningState.fromEvents() - Event Sourcing Reconstruction', () => {
+    let gameId: GameId;
+    let inningStateId: InningStateId;
+    let batterId1: PlayerId;
+    let batterId2: PlayerId;
+    let runner1: PlayerId;
+
+    beforeEach(() => {
+      gameId = GameId.generate();
+      inningStateId = InningStateId.generate();
+      batterId1 = new PlayerId('batter-1');
+      batterId2 = new PlayerId('batter-2');
+      runner1 = new PlayerId('runner-1');
+    });
+
+    describe('Core Event Reconstruction', () => {
+      it('should create inning state from InningStateCreated event', () => {
+        const events = [new InningStateCreated(inningStateId, gameId, 1, true)];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.id).toEqual(inningStateId);
+        expect(reconstructed.gameId).toEqual(gameId);
+        expect(reconstructed.inning).toBe(1);
+        expect(reconstructed.isTopHalf).toBe(true);
+        expect(reconstructed.outs).toBe(0);
+        expect(reconstructed.currentBattingSlot).toBe(1);
+        expect(reconstructed.basesState.getOccupiedBases()).toHaveLength(0);
+      });
+
+      it('should replay events in chronological order', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.SINGLE, 1, 0),
+          new RunnerAdvanced(gameId, batterId1, null, 'FIRST', AdvanceReason.HIT),
+          new CurrentBatterChanged(gameId, 1, 2, 1, true),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.basesState.getRunner('FIRST')).toEqual(batterId1);
+        expect(reconstructed.currentBattingSlot).toBe(2);
+        expect(reconstructed.outs).toBe(0);
+      });
+
+      it('should maintain domain invariants during reconstruction', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.STRIKEOUT, 1, 0),
+          new CurrentBatterChanged(gameId, 1, 2, 1, true),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        // Domain invariants maintained
+        expect(reconstructed.outs).toBe(1); // Out was recorded
+        expect(reconstructed.currentBattingSlot).toBe(2); // Batting order advanced
+        expect(reconstructed.basesState.getOccupiedBases()).toHaveLength(0); // No runners on base
+      });
+
+      it('should handle empty event array gracefully', () => {
+        expect(() => InningState.fromEvents([])).toThrow(DomainError);
+        expect(() => InningState.fromEvents([])).toThrow(
+          'Cannot reconstruct inning state from empty event array'
+        );
+      });
+
+      it('should throw error if first event is not InningStateCreated', () => {
+        const events = [new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.SINGLE, 1, 0)];
+
+        expect(() => InningState.fromEvents(events)).toThrow(DomainError);
+        expect(() => InningState.fromEvents(events)).toThrow(
+          'First event must be InningStateCreated'
+        );
+      });
+    });
+
+    describe('Complex Scenario Reconstruction', () => {
+      it('should reconstruct full inning with multiple at-bats', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 3, false),
+          // First at-bat: Single
+          new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.SINGLE, 3, 0),
+          new RunnerAdvanced(gameId, batterId1, null, 'FIRST', AdvanceReason.HIT),
+          new CurrentBatterChanged(gameId, 1, 2, 3, false),
+          // Second at-bat: Double, runner scores
+          new AtBatCompleted(gameId, batterId2, 2, AtBatResultType.DOUBLE, 3, 0),
+          new RunnerAdvanced(gameId, batterId1, 'FIRST', 'HOME', AdvanceReason.HIT),
+          new RunScored(gameId, batterId1, 'HOME', batterId2, { home: 1, away: 0 }),
+          new RunnerAdvanced(gameId, batterId2, null, 'SECOND', AdvanceReason.HIT),
+          new CurrentBatterChanged(gameId, 2, 3, 3, false),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.inning).toBe(3);
+        expect(reconstructed.isTopHalf).toBe(false);
+        expect(reconstructed.basesState.getRunner('SECOND')).toEqual(batterId2);
+        expect(reconstructed.basesState.getRunner('FIRST')).toBeUndefined();
+        expect(reconstructed.currentBattingSlot).toBe(3);
+        expect(reconstructed.outs).toBe(0);
+      });
+
+      it('should restore correct base runner positions', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new RunnerAdvanced(gameId, batterId1, null, 'FIRST', AdvanceReason.WALK),
+          new RunnerAdvanced(gameId, batterId2, null, 'SECOND', AdvanceReason.HIT),
+          new RunnerAdvanced(gameId, runner1, null, 'THIRD', AdvanceReason.HIT),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.basesState.getRunner('FIRST')).toEqual(batterId1);
+        expect(reconstructed.basesState.getRunner('SECOND')).toEqual(batterId2);
+        expect(reconstructed.basesState.getRunner('THIRD')).toEqual(runner1);
+        expect(reconstructed.basesState.getOccupiedBases()).toHaveLength(3);
+      });
+
+      it('should maintain accurate out count through replay', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.STRIKEOUT, 1, 0),
+          new AtBatCompleted(gameId, batterId2, 2, AtBatResultType.GROUND_OUT, 1, 1),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.outs).toBe(2);
+      });
+
+      it('should handle inning transitions correctly', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new HalfInningEnded(gameId, 1, true, 3),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.inning).toBe(1);
+        expect(reconstructed.isTopHalf).toBe(false); // Switched to bottom half
+        expect(reconstructed.outs).toBe(0); // Reset for new half
+        expect(reconstructed.currentBattingSlot).toBe(1); // Reset batting order
+        expect(reconstructed.basesState.getOccupiedBases()).toHaveLength(0); // Bases cleared
+      });
+
+      it('should preserve batting order progression', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new CurrentBatterChanged(gameId, 1, 2, 1, true),
+          new CurrentBatterChanged(gameId, 2, 3, 1, true),
+          new CurrentBatterChanged(gameId, 9, 1, 1, true),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.currentBattingSlot).toBe(1); // Cycled back to 1
+      });
+    });
+
+    describe('Edge Cases and Error Handling', () => {
+      it('should ignore unknown event types gracefully', () => {
+        // Create a mock unknown event that still extends DomainEvent
+        class UnknownEvent {
+          readonly eventId = crypto.randomUUID();
+          readonly timestamp = new Date();
+          readonly version = 1;
+          readonly type = 'UnknownEventType';
+          readonly gameId = gameId;
+          someProperty = 'someValue';
+        }
+
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new UnknownEvent() as unknown as DomainEvent,
+          new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.SINGLE, 1, 0),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        // Should process known events normally despite unknown event
+        expect(reconstructed.id).toEqual(inningStateId);
+        expect(reconstructed.inning).toBe(1);
+        // Unknown event should be ignored without causing errors
+      });
+
+      it('should handle malformed events gracefully', () => {
+        // Create a mock malformed event that still has required DomainEvent properties
+        class MalformedEvent {
+          readonly eventId = crypto.randomUUID();
+          readonly timestamp = new Date();
+          readonly version = 1;
+          readonly type = 'AtBatCompleted';
+          readonly gameId = gameId;
+          // Missing other required properties like batterId, etc.
+        }
+
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new MalformedEvent() as unknown as DomainEvent,
+        ];
+
+        // Should not crash during reconstruction
+        expect(() => InningState.fromEvents(events)).not.toThrow();
+      });
+
+      it('should be idempotent for repeat events', () => {
+        const batterChangeEvent = new CurrentBatterChanged(gameId, 1, 2, 1, true);
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          batterChangeEvent,
+          batterChangeEvent, // Repeat event
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        // Repeat event should not cause duplicate state changes
+        expect(reconstructed.currentBattingSlot).toBe(2);
+      });
+
+      it('should clear uncommitted events for reconstructed aggregate', () => {
+        const events = [new InningStateCreated(inningStateId, gameId, 1, true)];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        // Reconstructed aggregates should have no uncommitted events
+        expect(reconstructed.getUncommittedEvents()).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('InningState.applyEvent() - Event Application Logic', () => {
+    let gameId: GameId;
+    let inningStateId: InningStateId;
+    let batterId1: PlayerId;
+    let batterId2: PlayerId;
+    let runner1: PlayerId;
+
+    beforeEach(() => {
+      gameId = GameId.generate();
+      inningStateId = InningStateId.generate();
+      batterId1 = new PlayerId('batter-1');
+      batterId2 = new PlayerId('batter-2');
+      runner1 = new PlayerId('runner-1');
+    });
+
+    describe('AtBatCompleted Event Application', () => {
+      it('should apply AtBatCompleted event for strikeout (adds out)', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.STRIKEOUT, 1, 0),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.outs).toBe(1);
+        expect(reconstructed.currentBattingSlot).toBe(1); // No batter change event yet
+      });
+
+      it('should apply AtBatCompleted event for double play (adds 2 outs)', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.DOUBLE_PLAY, 1, 0),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.outs).toBe(2);
+      });
+
+      it('should apply AtBatCompleted event for triple play (adds 3 outs)', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.TRIPLE_PLAY, 1, 0),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.outs).toBe(3);
+      });
+
+      it('should not add outs for hit results', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.SINGLE, 1, 0),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.outs).toBe(0);
+      });
+    });
+
+    describe('RunnerAdvanced Event Application', () => {
+      it('should place runner on base for new advancement', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new RunnerAdvanced(gameId, batterId1, null, 'FIRST', AdvanceReason.HIT),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.basesState.getRunner('FIRST')).toEqual(batterId1);
+      });
+
+      it('should move runner from one base to another', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new RunnerAdvanced(gameId, batterId1, null, 'FIRST', AdvanceReason.HIT),
+          new RunnerAdvanced(gameId, batterId1, 'FIRST', 'SECOND', AdvanceReason.HIT),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.basesState.getRunner('FIRST')).toBeUndefined();
+        expect(reconstructed.basesState.getRunner('SECOND')).toEqual(batterId1);
+      });
+
+      it('should remove runner when advancing to HOME', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new RunnerAdvanced(gameId, batterId1, null, 'THIRD', AdvanceReason.HIT),
+          new RunnerAdvanced(gameId, batterId1, 'THIRD', 'HOME', AdvanceReason.HIT),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.basesState.getRunner('THIRD')).toBeUndefined();
+        expect(reconstructed.basesState.getOccupiedBases()).toHaveLength(0);
+      });
+
+      it('should remove runner when marked OUT', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new RunnerAdvanced(gameId, batterId1, null, 'FIRST', AdvanceReason.HIT),
+          new RunnerAdvanced(gameId, batterId2, null, 'SECOND', AdvanceReason.HIT),
+          new RunnerAdvanced(gameId, batterId1, 'FIRST', 'OUT', AdvanceReason.FIELDERS_CHOICE),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.basesState.getRunner('FIRST')).toBeUndefined();
+        expect(reconstructed.basesState.getRunner('SECOND')).toEqual(batterId2);
+        expect(reconstructed.basesState.getOccupiedBases()).toHaveLength(1);
+      });
+
+      it('should handle malformed RunnerAdvanced events gracefully', () => {
+        // Create a malformed RunnerAdvanced event
+        class MalformedRunnerAdvancedEvent {
+          readonly eventId = crypto.randomUUID();
+          readonly timestamp = new Date();
+          readonly version = 1;
+          readonly type = 'RunnerAdvanced';
+          readonly gameId = gameId;
+          // Missing runnerId and to properties
+          readonly from = 'FIRST';
+          readonly reason = 'HIT';
+        }
+
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new MalformedRunnerAdvancedEvent() as unknown as DomainEvent,
+        ];
+
+        // Should not crash
+        expect(() => InningState.fromEvents(events)).not.toThrow();
+
+        const reconstructed = InningState.fromEvents(events);
+        expect(reconstructed.basesState.getOccupiedBases()).toHaveLength(0);
+      });
+    });
+
+    describe('CurrentBatterChanged Event Application', () => {
+      it('should update current batting slot', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new CurrentBatterChanged(gameId, 1, 5, 1, true),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.currentBattingSlot).toBe(5);
+      });
+
+      it('should handle batting order cycling', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new CurrentBatterChanged(gameId, 9, 1, 1, true),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.currentBattingSlot).toBe(1);
+      });
+
+      it('should handle malformed CurrentBatterChanged events gracefully', () => {
+        // Create a malformed CurrentBatterChanged event
+        class MalformedCurrentBatterChangedEvent {
+          readonly eventId = crypto.randomUUID();
+          readonly timestamp = new Date();
+          readonly version = 1;
+          readonly type = 'CurrentBatterChanged';
+          readonly gameId = gameId;
+          readonly previousSlot = 1;
+          // Missing newSlot
+          readonly inning = 1;
+          readonly isTopHalf = true;
+        }
+
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new MalformedCurrentBatterChangedEvent() as unknown as DomainEvent,
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        // Should maintain original batting slot
+        expect(reconstructed.currentBattingSlot).toBe(1);
+      });
+    });
+
+    describe('HalfInningEnded Event Application', () => {
+      it('should switch from top to bottom half of inning', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 2, true),
+          new AtBatCompleted(gameId, batterId1, 1, AtBatResultType.STRIKEOUT, 2, 2),
+          new RunnerAdvanced(gameId, runner1, null, 'FIRST', AdvanceReason.HIT),
+          new HalfInningEnded(gameId, 2, true, 3),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.inning).toBe(2);
+        expect(reconstructed.isTopHalf).toBe(false); // Switched to bottom
+        expect(reconstructed.outs).toBe(0); // Reset
+        expect(reconstructed.currentBattingSlot).toBe(1); // Reset
+        expect(reconstructed.basesState.getOccupiedBases()).toHaveLength(0); // Bases cleared
+      });
+
+      it('should reset all tactical state', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new AtBatCompleted(gameId, batterId1, 7, AtBatResultType.STRIKEOUT, 1, 1),
+          new CurrentBatterChanged(gameId, 7, 8, 1, true),
+          new RunnerAdvanced(gameId, runner1, null, 'SECOND', AdvanceReason.HIT),
+          new HalfInningEnded(gameId, 1, true, 3),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.outs).toBe(0);
+        expect(reconstructed.currentBattingSlot).toBe(1);
+        expect(reconstructed.basesState.getOccupiedBases()).toHaveLength(0);
+      });
+    });
+
+    describe('InningAdvanced Event Application', () => {
+      it('should advance to next inning and set to top half', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 3, false),
+          new HalfInningEnded(gameId, 3, false, 3),
+          new InningAdvanced(gameId, 4, true),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.inning).toBe(4);
+        expect(reconstructed.isTopHalf).toBe(true);
+        expect(reconstructed.outs).toBe(0);
+        expect(reconstructed.currentBattingSlot).toBe(1);
+      });
+
+      it('should handle malformed InningAdvanced events gracefully', () => {
+        // Create a malformed InningAdvanced event
+        class MalformedInningAdvancedEvent {
+          readonly eventId = crypto.randomUUID();
+          readonly timestamp = new Date();
+          readonly version = 1;
+          readonly type = 'InningAdvanced';
+          readonly gameId = gameId;
+          // Missing newInning and isTopHalf
+        }
+
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new MalformedInningAdvancedEvent() as unknown as DomainEvent,
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        // Should maintain original state
+        expect(reconstructed.inning).toBe(1);
+        expect(reconstructed.isTopHalf).toBe(true);
+      });
+    });
+
+    describe('RunScored Event Application', () => {
+      it('should handle RunScored events without state changes', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new RunScored(gameId, batterId1, 'AWAY', batterId2, { home: 0, away: 1 }),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        // RunScored should not affect InningState directly
+        expect(reconstructed.outs).toBe(0);
+        expect(reconstructed.basesState.getOccupiedBases()).toHaveLength(0);
+        expect(reconstructed.currentBattingSlot).toBe(1);
+      });
+    });
+
+    describe('Event Processing Edge Cases', () => {
+      it('should be idempotent when applying same event multiple times', () => {
+        const batterChangeEvent = new CurrentBatterChanged(gameId, 1, 3, 1, true);
+
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          batterChangeEvent,
+          batterChangeEvent, // Duplicate event
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        // Should not cause issues, final state should be consistent
+        expect(reconstructed.currentBattingSlot).toBe(3);
+      });
+
+      it('should ignore completely unknown event types', () => {
+        // Create a completely unknown event type
+        class CompletelyUnknownEvent {
+          readonly eventId = crypto.randomUUID();
+          readonly timestamp = new Date();
+          readonly version = 1;
+          readonly type = 'CompletelyUnknownEventType';
+          readonly gameId = gameId;
+          readonly randomProperty = 'randomValue';
+        }
+
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new CompletelyUnknownEvent() as unknown as DomainEvent,
+          new CurrentBatterChanged(gameId, 1, 2, 1, true),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        // Should process known events normally
+        expect(reconstructed.currentBattingSlot).toBe(2);
+        expect(reconstructed.inning).toBe(1);
+      });
+    });
+  });
+
+  describe('Event Management Methods', () => {
+    let gameId: GameId;
+    let inningStateId: InningStateId;
+    let batterId: PlayerId;
+
+    beforeEach(() => {
+      gameId = GameId.generate();
+      inningStateId = InningStateId.generate();
+      batterId = new PlayerId('batter-1');
+    });
+
+    describe('getVersion()', () => {
+      it('should return version 1 after creation', () => {
+        const inningState = InningState.createNew(inningStateId, gameId);
+
+        expect(inningState.getVersion()).toBe(1);
+      });
+
+      it('should increment version when events are added', () => {
+        const inningState = InningState.createNew(inningStateId, gameId);
+        const initialVersion = inningState.getVersion();
+
+        const updated = inningState.recordAtBat(batterId, 1, AtBatResultType.SINGLE, 1);
+
+        // recordAtBat adds multiple events: AtBatCompleted + RunnerAdvanced + CurrentBatterChanged
+        expect(updated.getVersion()).toBeGreaterThan(initialVersion);
+        expect(updated.getVersion()).toBe(4); // 1 (creation) + 3 (at-bat events)
+      });
+
+      it('should preserve version through event sourcing reconstruction', () => {
+        const events = [
+          new InningStateCreated(inningStateId, gameId, 1, true),
+          new AtBatCompleted(gameId, batterId, 1, AtBatResultType.SINGLE, 1, 0),
+          new RunnerAdvanced(gameId, batterId, null, 'FIRST', AdvanceReason.HIT),
+        ];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.getVersion()).toBe(3); // 1 + 2 events applied
+      });
+
+      it('should maintain version consistency across multiple operations', () => {
+        let inningState = InningState.createNew(inningStateId, gameId);
+        const initialVersion = inningState.getVersion();
+
+        // Record multiple at-bats
+        inningState = inningState.recordAtBat(batterId, 1, AtBatResultType.SINGLE, 1);
+        const afterFirstAtBat = inningState.getVersion();
+        expect(afterFirstAtBat).toBeGreaterThan(initialVersion);
+
+        inningState = inningState.recordAtBat(new PlayerId('batter-2'), 2, AtBatResultType.WALK, 1);
+        const afterSecondAtBat = inningState.getVersion();
+        expect(afterSecondAtBat).toBeGreaterThan(afterFirstAtBat);
+
+        // Version should match the total number of events in the aggregate
+        const totalEvents = inningState.getUncommittedEvents().length;
+        expect(inningState.getVersion()).toBe(totalEvents);
+      });
+    });
+
+    describe('getUncommittedEvents()', () => {
+      it('should return copy of uncommitted events array', () => {
+        const inningState = InningState.createNew(inningStateId, gameId);
+
+        const events = inningState.getUncommittedEvents();
+        const eventsAgain = inningState.getUncommittedEvents();
+
+        // Should be different array instances
+        expect(events).not.toBe(eventsAgain);
+        // But with same content
+        expect(events).toEqual(eventsAgain);
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe('InningStateCreated');
+      });
+
+      it('should include all events from multiple operations', () => {
+        const inningState = InningState.createNew(inningStateId, gameId);
+
+        const updated = inningState
+          .recordAtBat(batterId, 1, AtBatResultType.SINGLE, 1)
+          .recordAtBat(new PlayerId('batter-2'), 2, AtBatResultType.WALK, 1);
+
+        const events = updated.getUncommittedEvents();
+
+        expect(events.length).toBeGreaterThan(5); // Creation + multiple at-bat events
+
+        // Check event types are included
+        const eventTypes = events.map(e => e.type);
+        expect(eventTypes).toContain('InningStateCreated');
+        expect(eventTypes).toContain('AtBatCompleted');
+        expect(eventTypes).toContain('RunnerAdvanced');
+        expect(eventTypes).toContain('CurrentBatterChanged');
+      });
+
+      it('should return empty array for reconstructed aggregates', () => {
+        const events = [new InningStateCreated(inningStateId, gameId, 1, true)];
+
+        const reconstructed = InningState.fromEvents(events);
+
+        expect(reconstructed.getUncommittedEvents()).toHaveLength(0);
+      });
+    });
+
+    describe('markEventsAsCommitted()', () => {
+      it('should clear uncommitted events array', () => {
+        const inningState = InningState.createNew(inningStateId, gameId);
+
+        expect(inningState.getUncommittedEvents()).toHaveLength(1);
+
+        inningState.markEventsAsCommitted();
+
+        expect(inningState.getUncommittedEvents()).toHaveLength(0);
+      });
+
+      it('should preserve version after marking events as committed', () => {
+        const inningState = InningState.createNew(inningStateId, gameId);
+        const versionBeforeCommit = inningState.getVersion();
+
+        inningState.markEventsAsCommitted();
+        const versionAfterCommit = inningState.getVersion();
+
+        expect(versionAfterCommit).toBe(versionBeforeCommit);
+      });
+
+      it('should work with complex event sequences', () => {
+        const inningState = InningState.createNew(inningStateId, gameId);
+
+        const updated = inningState
+          .recordAtBat(batterId, 1, AtBatResultType.SINGLE, 1)
+          .recordAtBat(new PlayerId('batter-2'), 2, AtBatResultType.DOUBLE, 1);
+
+        const eventsBeforeCommit = updated.getUncommittedEvents();
+        const versionBeforeCommit = updated.getVersion();
+
+        expect(eventsBeforeCommit.length).toBeGreaterThan(5);
+
+        updated.markEventsAsCommitted();
+
+        expect(updated.getUncommittedEvents()).toHaveLength(0);
+        expect(updated.getVersion()).toBe(versionBeforeCommit);
+      });
+    });
+
+    describe('Version Tracking Integration', () => {
+      it('should track version correctly throughout aggregate lifecycle', () => {
+        // Create new aggregate
+        let inningState = InningState.createNew(inningStateId, gameId);
+        expect(inningState.getVersion()).toBe(1);
+
+        // Add events
+        inningState = inningState.recordAtBat(batterId, 1, AtBatResultType.TRIPLE, 1);
+        const versionAfterTriple = inningState.getVersion();
+        expect(versionAfterTriple).toBeGreaterThan(1);
+
+        // End half inning
+        inningState = inningState
+          .withOuts(2)
+          .recordAtBat(new PlayerId('batter-2'), 2, AtBatResultType.STRIKEOUT, 1);
+        const versionAfterInningEnd = inningState.getVersion();
+        expect(versionAfterInningEnd).toBeGreaterThan(versionAfterTriple);
+
+        // Commit events
+        const versionBeforeCommit = inningState.getVersion();
+        inningState.markEventsAsCommitted();
+        expect(inningState.getVersion()).toBe(versionBeforeCommit);
+      });
+
+      it('should maintain version consistency during event sourcing round trip', () => {
+        // Create and modify aggregate
+        const original = InningState.createNew(inningStateId, gameId).recordAtBat(
+          batterId,
+          1,
+          AtBatResultType.HOME_RUN,
+          1
+        );
+
+        const originalEvents = original.getUncommittedEvents();
+        const originalVersion = originalEvents.length; // Version should equal event count
+
+        // Simulate persistence and reconstruction
+        const reconstructed = InningState.fromEvents(originalEvents);
+
+        expect(reconstructed.getVersion()).toBe(originalVersion);
+        expect(reconstructed.getUncommittedEvents()).toHaveLength(0);
+
+        // States should be equivalent
+        expect(reconstructed.inning).toBe(original.inning);
+        expect(reconstructed.isTopHalf).toBe(original.isTopHalf);
+        expect(reconstructed.outs).toBe(original.outs);
+        expect(reconstructed.currentBattingSlot).toBe(original.currentBattingSlot);
+      });
     });
   });
 });

--- a/packages/domain/src/aggregates/TeamLineup.test.ts
+++ b/packages/domain/src/aggregates/TeamLineup.test.ts
@@ -1,7 +1,10 @@
 import { FieldPosition } from '../constants/FieldPosition';
 import { DomainError } from '../errors/DomainError';
+import { DomainEvent } from '../events/DomainEvent';
 import { FieldPositionChanged } from '../events/FieldPositionChanged';
+import { PlayerAddedToLineup } from '../events/PlayerAddedToLineup';
 import { PlayerSubstitutedIntoGame } from '../events/PlayerSubstitutedIntoGame';
+import { TeamLineupCreated } from '../events/TeamLineupCreated';
 import { SoftballRules } from '../rules/SoftballRules';
 import { GameId } from '../value-objects/GameId';
 import { JerseyNumber } from '../value-objects/JerseyNumber';
@@ -1177,6 +1180,1620 @@ describe('TeamLineup', () => {
       expect(positions.get(FieldPosition.PITCHER)).toEqual(player3);
       expect(positions.get(FieldPosition.SHORTSTOP)).toEqual(player2);
       expect(positions.get(FieldPosition.FIRST_BASE)).toBeUndefined();
+    });
+  });
+
+  describe('TeamLineup.applyEvent() - Event Application Logic', () => {
+    let baseEvents: DomainEvent[];
+
+    beforeEach(() => {
+      // Base events for most tests: creation only
+      baseEvents = [new TeamLineupCreated(lineupId, gameId, 'Home Tigers')];
+    });
+
+    describe('TeamLineupCreated Event Application', () => {
+      it('should initialize empty lineup with correct identity', () => {
+        const event = new TeamLineupCreated(lineupId, gameId, 'Test Team');
+        const lineup = TeamLineup.fromEvents([event]);
+
+        expect(lineup.id).toEqual(lineupId);
+        expect(lineup.gameId).toEqual(gameId);
+        expect(lineup.teamName).toBe('Test Team');
+        expect(lineup.getActiveLineup()).toEqual([]);
+        expect(lineup.getFieldingPositions()).toEqual(new Map());
+        expect(lineup.getUncommittedEvents()).toHaveLength(0);
+        expect(lineup.getVersion()).toBe(1);
+      });
+
+      it('should maintain empty state after TeamLineupCreated event', () => {
+        const event = new TeamLineupCreated(lineupId, gameId, 'Empty Team');
+        const lineup = TeamLineup.fromEvents([event]);
+
+        expect(lineup.isLineupValid()).toBe(false);
+        expect(lineup.getPlayerInfo(player1)).toBeUndefined();
+        expect(lineup.isPlayerEligibleForReentry(player1)).toBe(false);
+      });
+    });
+
+    describe('PlayerAddedToLineup Event Application', () => {
+      it('should apply PlayerAddedToLineup event (add player to batting slot and field position)', () => {
+        const events = [
+          ...baseEvents,
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Pitcher',
+            1,
+            FieldPosition.PITCHER
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // Verify batting slot assignment
+        const activeLineup = lineup.getActiveLineup();
+        expect(activeLineup).toHaveLength(1);
+        expect(activeLineup[0]?.position).toBe(1);
+        expect(activeLineup[0]?.getCurrentPlayer()).toEqual(player1);
+        expect(activeLineup[0]?.wasPlayerStarter(player1)).toBe(true);
+
+        // Verify field position assignment
+        const fieldPositions = lineup.getFieldingPositions();
+        expect(fieldPositions.get(FieldPosition.PITCHER)).toEqual(player1);
+        expect(fieldPositions.size).toBe(1);
+
+        // Verify player history
+        const playerInfo = lineup.getPlayerInfo(player1);
+        expect(playerInfo).toBeDefined();
+        expect(playerInfo?.playerId).toEqual(player1);
+        expect(playerInfo?.jerseyNumber).toEqual(jersey1);
+        expect(playerInfo?.playerName).toBe('John Pitcher');
+        expect(playerInfo?.currentPosition).toBe(FieldPosition.PITCHER);
+        expect(playerInfo?.isStarter).toBe(true);
+        expect(playerInfo?.hasUsedReentry).toBe(false);
+      });
+
+      it('should apply PlayerAddedToLineup event with EXTRA_PLAYER position', () => {
+        const events = [
+          ...baseEvents,
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'Extra Batter',
+            10,
+            FieldPosition.EXTRA_PLAYER
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // EXTRA_PLAYER should be in batting lineup but not field positions
+        expect(lineup.getActiveLineup()).toHaveLength(1);
+        expect(lineup.getActiveLineup()[0]?.position).toBe(10);
+        expect(lineup.getFieldingPositions().size).toBe(0);
+        expect(lineup.getPlayerInfo(player1)?.currentPosition).toBeUndefined();
+      });
+
+      it('should apply multiple PlayerAddedToLineup events maintaining order', () => {
+        const events = [
+          ...baseEvents,
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player3,
+            jersey3,
+            'Third Player',
+            3,
+            FieldPosition.FIRST_BASE
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'First Player',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Second Player',
+            2,
+            FieldPosition.CATCHER
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        const activeLineup = lineup.getActiveLineup();
+        expect(activeLineup).toHaveLength(3);
+        // Should be sorted by batting position
+        expect(activeLineup[0]?.position).toBe(1);
+        expect(activeLineup[0]?.getCurrentPlayer()).toEqual(player1);
+        expect(activeLineup[1]?.position).toBe(2);
+        expect(activeLineup[1]?.getCurrentPlayer()).toEqual(player2);
+        expect(activeLineup[2]?.position).toBe(3);
+        expect(activeLineup[2]?.getCurrentPlayer()).toEqual(player3);
+      });
+
+      it('should apply PlayerAddedToLineup event with jersey number tracking', () => {
+        const events = [
+          ...baseEvents,
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'Player One',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Player Two',
+            2,
+            FieldPosition.CATCHER
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // Jersey numbers should be properly tracked
+        expect(lineup.getPlayerInfo(player1)?.jerseyNumber).toEqual(jersey1);
+        expect(lineup.getPlayerInfo(player2)?.jerseyNumber).toEqual(jersey2);
+
+        // All players should be marked as starters
+        expect(lineup.getPlayerInfo(player1)?.isStarter).toBe(true);
+        expect(lineup.getPlayerInfo(player2)?.isStarter).toBe(true);
+      });
+    });
+
+    describe('PlayerSubstitutedIntoGame Event Application', () => {
+      beforeEach(() => {
+        // Add base players for substitution tests
+        baseEvents = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'Starting Pitcher',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Starting Catcher',
+            2,
+            FieldPosition.CATCHER
+          ),
+        ];
+      });
+
+      it('should apply PlayerSubstitutedIntoGame event (substitute new player)', () => {
+        const events = [
+          ...baseEvents,
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            player3,
+            FieldPosition.FIRST_BASE,
+            5
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // Verify batting slot substitution
+        const activeLineup = lineup.getActiveLineup();
+        expect(activeLineup[0]?.getCurrentPlayer()).toEqual(player3);
+        expect(activeLineup[0]?.position).toBe(1);
+
+        // Verify field position change
+        const fieldPositions = lineup.getFieldingPositions();
+        expect(fieldPositions.get(FieldPosition.FIRST_BASE)).toEqual(player3);
+        expect(fieldPositions.get(FieldPosition.PITCHER)).toBeUndefined();
+
+        // Verify outgoing player status
+        const outgoingInfo = lineup.getPlayerInfo(player1);
+        expect(outgoingInfo?.currentPosition).toBeUndefined();
+        expect(lineup.isPlayerEligibleForReentry(player1)).toBe(true);
+
+        // Verify incoming player status (substitute, not starter)
+        const incomingInfo = lineup.getPlayerInfo(player3);
+        expect(incomingInfo?.isStarter).toBe(false);
+        expect(incomingInfo?.currentPosition).toBe(FieldPosition.FIRST_BASE);
+      });
+
+      it('should apply PlayerSubstitutedIntoGame event with EXTRA_PLAYER position', () => {
+        const events = [
+          ...baseEvents,
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            player3,
+            FieldPosition.EXTRA_PLAYER,
+            5
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // EXTRA_PLAYER doesn't occupy field positions
+        expect(lineup.getFieldingPositions().size).toBe(1); // Only player2 remains
+        expect(lineup.getFieldingPositions().get(FieldPosition.PITCHER)).toBeUndefined();
+        expect(lineup.getPlayerInfo(player3)?.currentPosition).toBeUndefined();
+      });
+
+      it('should apply PlayerSubstitutedIntoGame event for starter re-entry', () => {
+        const sub1 = PlayerId.generate();
+        const events = [
+          ...baseEvents,
+          // First substitution - starter out
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            sub1,
+            FieldPosition.FIRST_BASE,
+            3
+          ),
+          // Starter re-enters
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            sub1,
+            player1,
+            FieldPosition.PITCHER,
+            7
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // Verify re-entry
+        expect(lineup.getActiveLineup()[0]?.getCurrentPlayer()).toEqual(player1);
+        expect(lineup.getFieldingPositions().get(FieldPosition.PITCHER)).toEqual(player1);
+
+        // Verify re-entry tracking
+        expect(lineup.isPlayerEligibleForReentry(player1)).toBe(false); // Used re-entry
+        expect(lineup.getPlayerInfo(player1)?.hasUsedReentry).toBe(true);
+      });
+
+      it('should handle complex substitution chain with re-entry tracking', () => {
+        const sub1 = PlayerId.generate();
+        const sub2 = PlayerId.generate();
+        const events = [
+          ...baseEvents,
+          // First substitution
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            sub1,
+            FieldPosition.SHORTSTOP,
+            3
+          ),
+          // Second substitution
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            sub1,
+            sub2,
+            FieldPosition.SECOND_BASE,
+            5
+          ),
+          // Original starter re-enters
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            sub2,
+            player1,
+            FieldPosition.PITCHER,
+            8
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // Final state verification
+        expect(lineup.getActiveLineup()[0]?.getCurrentPlayer()).toEqual(player1);
+        expect(lineup.getFieldingPositions().get(FieldPosition.PITCHER)).toEqual(player1);
+
+        // Re-entry eligibility
+        expect(lineup.isPlayerEligibleForReentry(player1)).toBe(false); // Used re-entry
+        expect(lineup.isPlayerEligibleForReentry(sub1)).toBe(false); // Non-starter
+        expect(lineup.isPlayerEligibleForReentry(sub2)).toBe(false); // Non-starter
+      });
+
+      it('should maintain substitution history in batting slots', () => {
+        const sub1 = PlayerId.generate();
+        const events = [
+          ...baseEvents,
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            sub1,
+            FieldPosition.SHORTSTOP,
+            5
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+        const battingSlot = lineup.getActiveLineup()[0];
+
+        expect(battingSlot?.getCurrentPlayer()).toEqual(sub1);
+        expect(battingSlot?.getHistory().length).toBeGreaterThan(1);
+      });
+    });
+
+    describe('FieldPositionChanged Event Application', () => {
+      beforeEach(() => {
+        // Add base players for position change tests
+        baseEvents = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'Player One',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Player Two',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player3,
+            jersey3,
+            'Player Three',
+            3,
+            FieldPosition.FIRST_BASE
+          ),
+        ];
+      });
+
+      it('should apply FieldPositionChanged event (move player to new position)', () => {
+        const events = [
+          ...baseEvents,
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player1,
+            FieldPosition.PITCHER,
+            FieldPosition.SHORTSTOP,
+            4
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        const fieldPositions = lineup.getFieldingPositions();
+        expect(fieldPositions.get(FieldPosition.SHORTSTOP)).toEqual(player1);
+        expect(fieldPositions.get(FieldPosition.PITCHER)).toBeUndefined();
+        expect(fieldPositions.get(FieldPosition.CATCHER)).toEqual(player2); // Unchanged
+
+        // Verify player history update
+        expect(lineup.getPlayerInfo(player1)?.currentPosition).toBe(FieldPosition.SHORTSTOP);
+      });
+
+      it('should apply FieldPositionChanged event moving player to EXTRA_PLAYER', () => {
+        const events = [
+          ...baseEvents,
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player1,
+            FieldPosition.PITCHER,
+            FieldPosition.EXTRA_PLAYER,
+            3
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // EXTRA_PLAYER doesn't appear in field positions
+        expect(lineup.getFieldingPositions().get(FieldPosition.PITCHER)).toBeUndefined();
+        expect(lineup.getFieldingPositions().size).toBe(2); // player2 and player3 remain
+        expect(lineup.getPlayerInfo(player1)?.currentPosition).toBeUndefined();
+      });
+
+      it('should apply multiple FieldPositionChanged events in sequence', () => {
+        const events = [
+          ...baseEvents,
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player1,
+            FieldPosition.PITCHER,
+            FieldPosition.SHORTSTOP,
+            2
+          ),
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player2,
+            FieldPosition.CATCHER,
+            FieldPosition.PITCHER,
+            2
+          ),
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player3,
+            FieldPosition.FIRST_BASE,
+            FieldPosition.CATCHER,
+            2
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // Verify circular position swap
+        const fieldPositions = lineup.getFieldingPositions();
+        expect(fieldPositions.get(FieldPosition.SHORTSTOP)).toEqual(player1);
+        expect(fieldPositions.get(FieldPosition.PITCHER)).toEqual(player2);
+        expect(fieldPositions.get(FieldPosition.CATCHER)).toEqual(player3);
+        expect(fieldPositions.get(FieldPosition.FIRST_BASE)).toBeUndefined();
+      });
+
+      it('should handle position changes after substitutions', () => {
+        const sub1 = PlayerId.generate();
+        const events = [
+          ...baseEvents,
+          // Substitute player
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            sub1,
+            FieldPosition.FIRST_BASE,
+            3
+          ),
+          // Change substitute's position
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            sub1,
+            FieldPosition.FIRST_BASE,
+            FieldPosition.SHORTSTOP,
+            5
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getFieldingPositions().get(FieldPosition.SHORTSTOP)).toEqual(sub1);
+        expect(lineup.getFieldingPositions().get(FieldPosition.FIRST_BASE)).toBeUndefined();
+        expect(lineup.getPlayerInfo(sub1)?.currentPosition).toBe(FieldPosition.SHORTSTOP);
+      });
+    });
+
+    describe('Unknown Event Types', () => {
+      it('should ignore unknown event types gracefully', () => {
+        const unknownEvent = {
+          id: 'unknown-event-id',
+          type: 'UnknownEventType',
+          gameId,
+          teamLineupId: lineupId,
+          timestamp: new Date(),
+          aggregateVersion: 1,
+        } as unknown as DomainEvent;
+
+        const events: DomainEvent[] = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          unknownEvent,
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Jane Smith',
+            2,
+            FieldPosition.CATCHER
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // Should process known events normally and ignore unknown ones
+        expect(lineup.getActiveLineup()).toHaveLength(2);
+        expect(lineup.getFieldingPositions().size).toBe(2);
+        expect(lineup.getPlayerInfo(player1)).toBeDefined();
+        expect(lineup.getPlayerInfo(player2)).toBeDefined();
+      });
+
+      it('should handle event with no type property', () => {
+        const malformedEvent = {
+          id: 'malformed-event-id',
+          gameId,
+          teamLineupId: lineupId,
+          timestamp: new Date(),
+          aggregateVersion: 1,
+        } as unknown as DomainEvent;
+
+        const events: DomainEvent[] = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          malformedEvent,
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // Should ignore malformed event and process others
+        expect(lineup.getActiveLineup()).toHaveLength(1);
+        expect(lineup.getPlayerInfo(player1)).toBeDefined();
+      });
+    });
+
+    describe('Event Idempotency', () => {
+      it('should be idempotent (same event sequence produces identical results)', () => {
+        const eventSequence = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Jane Smith',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            player3,
+            FieldPosition.FIRST_BASE,
+            5
+          ),
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player2,
+            FieldPosition.CATCHER,
+            FieldPosition.SHORTSTOP,
+            6
+          ),
+        ];
+
+        const lineup1 = TeamLineup.fromEvents([...eventSequence]);
+        const lineup2 = TeamLineup.fromEvents([...eventSequence]);
+
+        // Should produce identical results
+        expect(lineup1.getActiveLineup()).toEqual(lineup2.getActiveLineup());
+        expect(lineup1.getFieldingPositions()).toEqual(lineup2.getFieldingPositions());
+        expect(lineup1.getPlayerInfo(player1)).toEqual(lineup2.getPlayerInfo(player1));
+        expect(lineup1.getPlayerInfo(player2)).toEqual(lineup2.getPlayerInfo(player2));
+        expect(lineup1.getPlayerInfo(player3)).toEqual(lineup2.getPlayerInfo(player3));
+        expect(lineup1.isPlayerEligibleForReentry(player1)).toBe(
+          lineup2.isPlayerEligibleForReentry(player1)
+        );
+      });
+
+      it('should handle duplicate event application gracefully', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+        ];
+
+        const lineup1 = TeamLineup.fromEvents(events);
+        const lineup2 = TeamLineup.fromEvents(events);
+
+        // Multiple reconstructions should be identical
+        expect(lineup1.getActiveLineup()).toEqual(lineup2.getActiveLineup());
+        expect(lineup1.getVersion()).toBe(lineup2.getVersion());
+        expect(lineup1.teamName).toBe(lineup2.teamName);
+      });
+    });
+
+    describe('Domain Invariants During Event Application', () => {
+      it('should maintain domain invariants after applying events', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'Pitcher',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Catcher',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            player3,
+            FieldPosition.FIRST_BASE,
+            3
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // Batting slots should be properly maintained
+        expect(lineup.getActiveLineup()).toHaveLength(2);
+        expect(
+          lineup.getActiveLineup().every(slot => slot.position >= 1 && slot.position <= 20)
+        ).toBe(true);
+
+        // Field positions should be unique (except EXTRA_PLAYER)
+        const fieldPositions = lineup.getFieldingPositions();
+        const positions = Array.from(fieldPositions.keys());
+        const uniquePositions = new Set(positions);
+        expect(positions.length).toBe(uniquePositions.size);
+
+        // Player info should be consistent
+        expect(lineup.getPlayerInfo(player1)?.currentPosition).toBeUndefined(); // Substituted out
+        expect(lineup.getPlayerInfo(player2)?.currentPosition).toBe(FieldPosition.CATCHER);
+        expect(lineup.getPlayerInfo(player3)?.currentPosition).toBe(FieldPosition.FIRST_BASE);
+      });
+
+      it('should maintain jersey number uniqueness across all events', () => {
+        const sub1 = PlayerId.generate();
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'Player 1',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Player 2',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            sub1,
+            FieldPosition.FIRST_BASE,
+            3
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // All active players should have unique jersey numbers
+        const activeJerseys = new Set([
+          lineup.getPlayerInfo(player2)?.jerseyNumber.value,
+          lineup.getPlayerInfo(sub1)?.jerseyNumber.value,
+        ]);
+        expect(activeJerseys.size).toBe(2);
+      });
+
+      it('should maintain re-entry eligibility rules throughout event stream', () => {
+        const sub1 = PlayerId.generate();
+        const sub2 = PlayerId.generate();
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'Starter',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Another Starter',
+            2,
+            FieldPosition.CATCHER
+          ),
+          // First substitution
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            sub1,
+            FieldPosition.FIRST_BASE,
+            3
+          ),
+          // Second substitution
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            sub1,
+            sub2,
+            FieldPosition.SHORTSTOP,
+            5
+          ),
+          // Original starter re-enters
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            sub2,
+            player1,
+            FieldPosition.PITCHER,
+            8
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        // Re-entry rules should be properly maintained
+        expect(lineup.isPlayerEligibleForReentry(player1)).toBe(false); // Used re-entry
+        expect(lineup.isPlayerEligibleForReentry(player2)).toBe(false); // Still active, not substituted
+        expect(lineup.isPlayerEligibleForReentry(sub1)).toBe(false); // Non-starter
+        expect(lineup.isPlayerEligibleForReentry(sub2)).toBe(false); // Non-starter
+
+        // Player history should reflect re-entry usage
+        expect(lineup.getPlayerInfo(player1)?.hasUsedReentry).toBe(true);
+        expect(lineup.getPlayerInfo(player2)?.hasUsedReentry).toBe(false);
+      });
+    });
+  });
+
+  describe('TeamLineup.fromEvents() - Event Sourcing Reconstruction', () => {
+    describe('Basic Reconstruction', () => {
+      it('should create lineup from TeamLineupCreated event', () => {
+        const events = [new TeamLineupCreated(lineupId, gameId, 'Home Tigers')];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.id).toEqual(lineupId);
+        expect(lineup.gameId).toEqual(gameId);
+        expect(lineup.teamName).toBe('Home Tigers');
+        expect(lineup.getActiveLineup()).toEqual([]);
+        expect(lineup.getFieldingPositions()).toEqual(new Map());
+        expect(lineup.getUncommittedEvents()).toHaveLength(0); // Events are already committed
+        expect(lineup.isLineupValid()).toBe(false); // No players yet
+      });
+
+      it('should replay events in chronological order', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Jane Smith',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            player3,
+            FieldPosition.FIRST_BASE,
+            5
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getActiveLineup()).toHaveLength(2);
+        expect(lineup.getActiveLineup()[0]?.getCurrentPlayer()).toEqual(player3); // player3 substituted for player1
+        expect(lineup.getActiveLineup()[1]?.getCurrentPlayer()).toEqual(player2); // player2 unchanged
+        expect(lineup.getFieldingPositions().get(FieldPosition.FIRST_BASE)).toEqual(player3);
+        expect(lineup.getFieldingPositions().get(FieldPosition.CATCHER)).toEqual(player2);
+        expect(lineup.getFieldingPositions().get(FieldPosition.PITCHER)).toBeUndefined(); // player1 was at pitcher before substitution
+      });
+
+      it('should maintain domain invariants during reconstruction', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Jane Smith',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player1,
+            FieldPosition.PITCHER,
+            FieldPosition.SHORTSTOP,
+            3
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getActiveLineup()).toHaveLength(2);
+        expect(lineup.getFieldingPositions().get(FieldPosition.SHORTSTOP)).toEqual(player1);
+        expect(lineup.getFieldingPositions().get(FieldPosition.PITCHER)).toBeUndefined();
+        expect(lineup.getFieldingPositions().get(FieldPosition.CATCHER)).toEqual(player2);
+        expect(lineup.getPlayerInfo(player1)?.currentPosition).toBe(FieldPosition.SHORTSTOP);
+      });
+    });
+
+    describe('Error Handling', () => {
+      it('should throw error for empty event array', () => {
+        expect(() => TeamLineup.fromEvents([])).toThrow(DomainError);
+      });
+
+      it('should throw error if first event is not TeamLineupCreated', () => {
+        const events = [
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+        ];
+
+        expect(() => TeamLineup.fromEvents(events)).toThrow(DomainError);
+      });
+
+      it('should throw error for events with different teamLineupId', () => {
+        const differentLineupId = TeamLineupId.generate();
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            differentLineupId, // Different lineup ID
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+        ];
+
+        expect(() => TeamLineup.fromEvents(events)).toThrow(DomainError);
+      });
+
+      it('should throw error for events with different gameId', () => {
+        const differentGameId = GameId.generate();
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            differentGameId, // Different game ID
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+        ];
+
+        expect(() => TeamLineup.fromEvents(events)).toThrow(DomainError);
+      });
+    });
+
+    describe('Event Processing', () => {
+      it('should process PlayerAddedToLineup events correctly', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Jane Smith',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player3,
+            jersey3,
+            'Bob Johnson',
+            10,
+            FieldPosition.EXTRA_PLAYER
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getActiveLineup()).toHaveLength(3);
+        expect(lineup.getFieldingPositions().size).toBe(2); // EXTRA_PLAYER doesn't count
+        expect(lineup.getPlayerInfo(player1)?.isStarter).toBe(true);
+        expect(lineup.getPlayerInfo(player2)?.isStarter).toBe(true);
+        expect(lineup.getPlayerInfo(player3)?.isStarter).toBe(true);
+        expect(lineup.getPlayerInfo(player3)?.currentPosition).toBeUndefined(); // EXTRA_PLAYER has no field position
+      });
+
+      it('should process PlayerSubstitutedIntoGame events correctly', () => {
+        const sub1 = PlayerId.generate();
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            sub1,
+            FieldPosition.CATCHER,
+            5
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getActiveLineup()).toHaveLength(1);
+        expect(lineup.getActiveLineup()[0]?.getCurrentPlayer()).toEqual(sub1);
+        expect(lineup.getFieldingPositions().get(FieldPosition.CATCHER)).toEqual(sub1);
+        expect(lineup.getFieldingPositions().get(FieldPosition.PITCHER)).toBeUndefined();
+        expect(lineup.isPlayerEligibleForReentry(player1)).toBe(true); // Starter can re-enter
+        expect(lineup.isPlayerEligibleForReentry(sub1)).toBe(false); // Substitute cannot
+      });
+
+      it('should process FieldPositionChanged events correctly', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Jane Smith',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player1,
+            FieldPosition.PITCHER,
+            FieldPosition.FIRST_BASE,
+            3
+          ),
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player2,
+            FieldPosition.CATCHER,
+            FieldPosition.PITCHER,
+            3
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getFieldingPositions().get(FieldPosition.FIRST_BASE)).toEqual(player1);
+        expect(lineup.getFieldingPositions().get(FieldPosition.PITCHER)).toEqual(player2);
+        expect(lineup.getFieldingPositions().get(FieldPosition.CATCHER)).toBeUndefined();
+        expect(lineup.getPlayerInfo(player1)?.currentPosition).toBe(FieldPosition.FIRST_BASE);
+        expect(lineup.getPlayerInfo(player2)?.currentPosition).toBe(FieldPosition.PITCHER);
+      });
+
+      it('should handle events with mixed timestamps in chronological order', () => {
+        const now = new Date();
+        const event1 = new TeamLineupCreated(lineupId, gameId, 'Home Tigers');
+        const event2 = new PlayerAddedToLineup(
+          gameId,
+          lineupId,
+          player1,
+          jersey1,
+          'John Doe',
+          1,
+          FieldPosition.PITCHER
+        );
+        const event3 = new PlayerAddedToLineup(
+          gameId,
+          lineupId,
+          player2,
+          jersey2,
+          'Jane Smith',
+          2,
+          FieldPosition.CATCHER
+        );
+
+        // Set timestamps to ensure proper ordering (event1 = oldest, event3 = newest)
+        Object.defineProperty(event1, 'timestamp', {
+          value: new Date(now.getTime() - 2000),
+          writable: false,
+        });
+        Object.defineProperty(event2, 'timestamp', {
+          value: new Date(now.getTime() - 1000),
+          writable: false,
+        });
+        Object.defineProperty(event3, 'timestamp', {
+          value: now,
+          writable: false,
+        });
+
+        const events = [event1, event2, event3];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getActiveLineup()).toHaveLength(2);
+        expect(lineup.getActiveLineup()[0]?.getCurrentPlayer()).toEqual(player1);
+        expect(lineup.getActiveLineup()[1]?.getCurrentPlayer()).toEqual(player2);
+      });
+    });
+
+    describe('Complex Lineup Scenarios', () => {
+      it('should handle full roster with substitutions and re-entries', () => {
+        const sub1 = PlayerId.generate();
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          // Add starter lineup
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Jane Smith',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player3,
+            jersey3,
+            'Bob Johnson',
+            3,
+            FieldPosition.FIRST_BASE
+          ),
+          // Substitute starter out
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            sub1,
+            FieldPosition.SHORTSTOP,
+            3
+          ),
+          // Starter re-enters
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            sub1,
+            player1,
+            FieldPosition.PITCHER,
+            7
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getActiveLineup()).toHaveLength(3);
+        expect(lineup.getActiveLineup()[0]?.getCurrentPlayer()).toEqual(player1); // Re-entered
+        expect(lineup.getFieldingPositions().get(FieldPosition.PITCHER)).toEqual(player1);
+        expect(lineup.isPlayerEligibleForReentry(player1)).toBe(false); // Used re-entry
+        expect(lineup.getPlayerInfo(player1)?.hasUsedReentry).toBe(true);
+      });
+
+      it('should handle position changes with substitutions', () => {
+        const sub1 = PlayerId.generate();
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Jane Smith',
+            2,
+            FieldPosition.CATCHER
+          ),
+          // Position change before substitution
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player1,
+            FieldPosition.PITCHER,
+            FieldPosition.FIRST_BASE,
+            2
+          ),
+          // Substitute player who changed positions
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            sub1,
+            FieldPosition.PITCHER,
+            4
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getActiveLineup()).toHaveLength(2);
+        expect(lineup.getFieldingPositions().get(FieldPosition.PITCHER)).toEqual(sub1);
+        expect(lineup.getFieldingPositions().get(FieldPosition.FIRST_BASE)).toBeUndefined(); // player1 was removed
+        expect(lineup.getFieldingPositions().get(FieldPosition.CATCHER)).toEqual(player2);
+      });
+
+      it('should handle EXTRA_PLAYER scenarios correctly', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          // Add regular player
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          // Add EXTRA_PLAYER (batting-only)
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Jane Smith',
+            10,
+            FieldPosition.EXTRA_PLAYER
+          ),
+          // Move regular player to EXTRA_PLAYER
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player1,
+            FieldPosition.PITCHER,
+            FieldPosition.EXTRA_PLAYER,
+            5
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getActiveLineup()).toHaveLength(2);
+        expect(lineup.getFieldingPositions().size).toBe(0); // No defensive players
+        expect(lineup.getPlayerInfo(player1)?.currentPosition).toBeUndefined(); // EXTRA_PLAYER has no position
+        expect(lineup.getPlayerInfo(player2)?.currentPosition).toBeUndefined(); // EXTRA_PLAYER has no position
+        expect(lineup.isLineupValid()).toBe(false); // No defensive coverage
+      });
+
+      it('should maintain re-entry eligibility tracking through complex substitutions', () => {
+        const sub1 = PlayerId.generate();
+        const sub2 = PlayerId.generate();
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          // Add starters
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'Starter 1',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Starter 2',
+            2,
+            FieldPosition.CATCHER
+          ),
+          // First wave of substitutions
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            sub1,
+            FieldPosition.FIRST_BASE,
+            3
+          ),
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            2,
+            player2,
+            sub2,
+            FieldPosition.SHORTSTOP,
+            4
+          ),
+          // One starter re-enters
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            sub1,
+            player1,
+            FieldPosition.PITCHER,
+            7
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.isPlayerEligibleForReentry(player1)).toBe(false); // Used re-entry
+        expect(lineup.isPlayerEligibleForReentry(player2)).toBe(true); // Still eligible
+        expect(lineup.isPlayerEligibleForReentry(sub1)).toBe(false); // Non-starter, not eligible
+        expect(lineup.isPlayerEligibleForReentry(sub2)).toBe(false); // Non-starter, not eligible
+        expect(lineup.getPlayerInfo(player1)?.hasUsedReentry).toBe(true);
+        expect(lineup.getPlayerInfo(player2)?.hasUsedReentry).toBe(false);
+      });
+    });
+
+    describe('State Consistency', () => {
+      it('should maintain batting order consistency across events', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Second Batter',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'First Batter',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player3,
+            jersey3,
+            'Third Batter',
+            3,
+            FieldPosition.FIRST_BASE
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+        const activeLineup = lineup.getActiveLineup();
+
+        expect(activeLineup).toHaveLength(3);
+        expect(activeLineup[0]?.position).toBe(1);
+        expect(activeLineup[1]?.position).toBe(2);
+        expect(activeLineup[2]?.position).toBe(3);
+        expect(activeLineup[0]?.getCurrentPlayer()).toEqual(player1);
+        expect(activeLineup[1]?.getCurrentPlayer()).toEqual(player2);
+        expect(activeLineup[2]?.getCurrentPlayer()).toEqual(player3);
+      });
+
+      it('should maintain field position consistency across changes', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player2,
+            jersey2,
+            'Jane Smith',
+            2,
+            FieldPosition.CATCHER
+          ),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player3,
+            jersey3,
+            'Bob Johnson',
+            3,
+            FieldPosition.FIRST_BASE
+          ),
+          // Complex position swaps
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player1,
+            FieldPosition.PITCHER,
+            FieldPosition.SHORTSTOP,
+            3
+          ),
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player2,
+            FieldPosition.CATCHER,
+            FieldPosition.PITCHER,
+            3
+          ),
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player3,
+            FieldPosition.FIRST_BASE,
+            FieldPosition.CATCHER,
+            3
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+        const positions = lineup.getFieldingPositions();
+
+        expect(positions.get(FieldPosition.SHORTSTOP)).toEqual(player1);
+        expect(positions.get(FieldPosition.PITCHER)).toEqual(player2);
+        expect(positions.get(FieldPosition.CATCHER)).toEqual(player3);
+        expect(positions.get(FieldPosition.FIRST_BASE)).toBeUndefined();
+      });
+
+      it('should preserve team identity throughout event stream', () => {
+        const teamName = 'Springfield Nuclear Plant Workers';
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, teamName),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'Homer Simpson',
+            1,
+            FieldPosition.PITCHER
+          ),
+          new PlayerSubstitutedIntoGame(
+            gameId,
+            lineupId,
+            1,
+            player1,
+            player2,
+            FieldPosition.CATCHER,
+            5
+          ),
+          new FieldPositionChanged(
+            gameId,
+            lineupId,
+            player2,
+            FieldPosition.CATCHER,
+            FieldPosition.SHORTSTOP,
+            7
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.teamName).toBe(teamName);
+        expect(lineup.id).toEqual(lineupId);
+        expect(lineup.gameId).toEqual(gameId);
+      });
+    });
+
+    describe('Performance and Edge Cases', () => {
+      it('should handle empty uncommitted events after reconstruction', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.getUncommittedEvents()).toHaveLength(0);
+        expect(lineup.getActiveLineup()).toHaveLength(1);
+      });
+
+      it('should handle single TeamLineupCreated event', () => {
+        const events = [new TeamLineupCreated(lineupId, gameId, 'Home Tigers')];
+
+        const lineup = TeamLineup.fromEvents(events);
+
+        expect(lineup.id).toEqual(lineupId);
+        expect(lineup.gameId).toEqual(gameId);
+        expect(lineup.teamName).toBe('Home Tigers');
+        expect(lineup.getActiveLineup()).toHaveLength(0);
+        expect(lineup.isLineupValid()).toBe(false);
+      });
+
+      it('should maintain immutability of reconstructed lineup', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new PlayerAddedToLineup(
+            gameId,
+            lineupId,
+            player1,
+            jersey1,
+            'John Doe',
+            1,
+            FieldPosition.PITCHER
+          ),
+        ];
+
+        const lineup = TeamLineup.fromEvents(events);
+        const originalActiveLineup = lineup.getActiveLineup();
+        const originalFieldingPositions = lineup.getFieldingPositions();
+
+        // Lineup properties should be immutable from external access
+        expect(lineup.getActiveLineup()).toEqual(originalActiveLineup);
+        expect(lineup.getFieldingPositions()).toEqual(originalFieldingPositions);
+        expect(lineup.id).toEqual(lineupId);
+        expect(lineup.gameId).toEqual(gameId);
+        expect(lineup.teamName).toBe('Home Tigers');
+      });
+
+      it('should handle duplicate TeamLineupCreated events gracefully', () => {
+        const events = [
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'),
+          new TeamLineupCreated(lineupId, gameId, 'Home Tigers'), // Duplicate
+        ];
+
+        // Should throw error on duplicate creation event
+        expect(() => TeamLineup.fromEvents(events)).toThrow(DomainError);
+      });
     });
   });
 });

--- a/packages/domain/src/integration/event-sourcing.test.ts
+++ b/packages/domain/src/integration/event-sourcing.test.ts
@@ -1,0 +1,675 @@
+import { Game } from '../aggregates/Game';
+import { InningState } from '../aggregates/InningState';
+import { TeamLineup } from '../aggregates/TeamLineup';
+import { FieldPosition } from '../constants/FieldPosition';
+import { GameStatus } from '../constants/GameStatus';
+import { DomainError } from '../errors/DomainError';
+import { DomainEvent } from '../events/DomainEvent';
+import { GameCompleted } from '../events/GameCompleted';
+import { GameCreated } from '../events/GameCreated';
+import { GameStarted } from '../events/GameStarted';
+import { InningAdvanced } from '../events/InningAdvanced';
+import { InningStateCreated } from '../events/InningStateCreated';
+import { PlayerAddedToLineup } from '../events/PlayerAddedToLineup';
+import { ScoreUpdated } from '../events/ScoreUpdated';
+import { TeamLineupCreated } from '../events/TeamLineupCreated';
+import { TestGameFactory } from '../test-utils/TestGameFactory';
+import { GameId } from '../value-objects/GameId';
+import { InningStateId } from '../value-objects/InningStateId';
+import { JerseyNumber } from '../value-objects/JerseyNumber';
+import { PlayerId } from '../value-objects/PlayerId';
+import { TeamLineupId } from '../value-objects/TeamLineupId';
+
+/**
+ * Cross-aggregate event sourcing integration tests for Phase 4.1 completion.
+ *
+ * Tests the complete event sourcing implementation across Game, TeamLineup,
+ * and InningState aggregates to ensure proper state reconstruction, event
+ * ordering, complex game scenarios, and performance characteristics.
+ */
+describe('Event Sourcing Cross-Aggregate Integration', () => {
+  let gameId: GameId;
+  let homeLineupId: TeamLineupId;
+  let inningStateId: InningStateId;
+  let players: Array<{ id: PlayerId; name: string; jersey: JerseyNumber }>;
+
+  beforeEach(() => {
+    gameId = TestGameFactory.createGameId('integration');
+    homeLineupId = new TeamLineupId(`home-lineup-${Date.now()}`);
+    inningStateId = new InningStateId(`inning-state-${Date.now()}`);
+
+    // Create test players
+    players = Array.from({ length: 18 }, (_, i) => ({
+      id: new PlayerId(`player-${i + 1}`),
+      name: `Player ${i + 1}`,
+      jersey: new JerseyNumber((i + 1).toString()),
+    }));
+  });
+
+  describe('Full Game State Reconstruction', () => {
+    it('should reconstruct complete game state from mixed events', () => {
+      // Arrange: Create comprehensive event sequence
+      const events: DomainEvent[] = [
+        new GameCreated(gameId, 'Eagles', 'Hawks'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 2, { home: 2, away: 0 }),
+        new InningAdvanced(gameId, 1, false),
+        new ScoreUpdated(gameId, 'AWAY', 1, { home: 2, away: 1 }),
+        new InningAdvanced(gameId, 2, true),
+        new GameCompleted(gameId, 'REGULATION', { home: 5, away: 3 }, 7),
+      ];
+
+      // Act: Reconstruct game aggregate
+      const game = Game.fromEvents(events);
+
+      // Assert: Validate complete reconstruction
+      expect(game.status).toBe(GameStatus.COMPLETED);
+      expect(game.homeTeamName).toBe('Eagles');
+      expect(game.awayTeamName).toBe('Hawks');
+      expect(game.score.getHomeRuns()).toBe(5);
+      expect(game.score.getAwayRuns()).toBe(3);
+      expect(game.currentInning).toBe(2);
+      expect(game.isTopHalf).toBe(true);
+    });
+
+    it('should maintain consistency across all three aggregates', () => {
+      // Arrange: Create events with cross-aggregate consistency requirements
+      const gameEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Team A', 'Team B'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 3, { home: 3, away: 0 }),
+        new InningAdvanced(gameId, 2, true),
+      ];
+
+      const lineupEvents: DomainEvent[] = [
+        new TeamLineupCreated(homeLineupId, gameId, 'HOME'),
+        new PlayerAddedToLineup(
+          gameId,
+          homeLineupId,
+          players[0]!.id,
+          players[0]!.jersey,
+          players[0]!.name,
+          1,
+          FieldPosition.PITCHER
+        ),
+        new PlayerAddedToLineup(
+          gameId,
+          homeLineupId,
+          players[1]!.id,
+          players[1]!.jersey,
+          players[1]!.name,
+          2,
+          FieldPosition.CATCHER
+        ),
+        new PlayerAddedToLineup(
+          gameId,
+          homeLineupId,
+          players[2]!.id,
+          players[2]!.jersey,
+          players[2]!.name,
+          3,
+          FieldPosition.FIRST_BASE
+        ),
+      ];
+
+      const inningEvents: DomainEvent[] = [new InningStateCreated(inningStateId, gameId, 1, true)];
+
+      // Act: Reconstruct aggregates independently
+      const game = Game.fromEvents(gameEvents);
+      const lineup = TeamLineup.fromEvents(lineupEvents);
+      const inning = InningState.fromEvents(inningEvents);
+
+      // Assert: Cross-aggregate consistency
+      expect(game.status).toBe(GameStatus.IN_PROGRESS);
+      expect(game.score.getHomeRuns()).toBe(3);
+      expect(game.currentInning).toBe(2);
+
+      expect(lineup.getActiveLineup()).toHaveLength(3);
+
+      expect(inning.inning).toBe(1);
+      expect(inning.isTopHalf).toBe(true);
+    });
+
+    it('should handle complex event sequences correctly', () => {
+      // Arrange: Create complex sequence with multiple innings
+      const events: DomainEvent[] = [
+        new GameCreated(gameId, 'Starters', 'Subs'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+        new InningAdvanced(gameId, 1, false), // Bottom 1st
+        new ScoreUpdated(gameId, 'AWAY', 2, { home: 1, away: 2 }),
+        new InningAdvanced(gameId, 2, true), // Top 2nd
+        new ScoreUpdated(gameId, 'HOME', 1, { home: 2, away: 2 }),
+        new InningAdvanced(gameId, 2, false), // Bottom 2nd
+      ];
+
+      // Act: Reconstruct with complex sequence
+      const game = Game.fromEvents(events);
+
+      // Assert: Complex sequence handling
+      expect(game.status).toBe(GameStatus.IN_PROGRESS);
+      expect(game.currentInning).toBe(2);
+      expect(game.isTopHalf).toBe(false);
+      expect(game.score.getHomeRuns()).toBe(2);
+      expect(game.score.getAwayRuns()).toBe(2);
+      // Verify tied game
+      expect(game.score.getHomeRuns()).toBe(game.score.getAwayRuns());
+    });
+
+    it('should support partial replay scenarios', () => {
+      // Arrange: Create full game event sequence
+      const allEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Full', 'Partial'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 3, { home: 3, away: 0 }),
+        new InningAdvanced(gameId, 2, true),
+        new ScoreUpdated(gameId, 'AWAY', 2, { home: 3, away: 2 }),
+        new InningAdvanced(gameId, 3, true),
+        new GameCompleted(gameId, 'REGULATION', { home: 5, away: 4 }, 7),
+      ];
+
+      // Act: Test partial replay at different points
+      const earlyEvents = allEvents.slice(0, 3); // Up to first score update
+      const midEvents = allEvents.slice(0, 5); // Up to second score update
+      const fullEvents = allEvents; // Complete sequence
+
+      const earlyGame = Game.fromEvents(earlyEvents);
+      const midGame = Game.fromEvents(midEvents);
+      const fullGame = Game.fromEvents(fullEvents);
+
+      // Assert: Partial replay accuracy
+      expect(earlyGame.status).toBe(GameStatus.IN_PROGRESS);
+      expect(earlyGame.score.getHomeRuns()).toBe(3);
+
+      expect(midGame.status).toBe(GameStatus.IN_PROGRESS);
+      expect(midGame.score.getHomeRuns()).toBe(3);
+      expect(midGame.score.getAwayRuns()).toBe(2);
+
+      expect(fullGame.status).toBe(GameStatus.COMPLETED);
+      expect(fullGame.score.getHomeRuns()).toBe(5);
+      expect(fullGame.score.getAwayRuns()).toBe(4);
+    });
+  });
+
+  describe('Event Ordering & Consistency', () => {
+    it('should apply events in strict chronological order', () => {
+      // Arrange: Create events with timestamps to ensure ordering matters
+      const baseTime = Date.now();
+      const events: DomainEvent[] = [
+        new GameCreated(gameId, 'Order', 'Test'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+        new ScoreUpdated(gameId, 'HOME', 2, { home: 3, away: 0 }),
+        new ScoreUpdated(gameId, 'AWAY', 1, { home: 3, away: 1 }),
+      ];
+
+      // Add timestamps to ensure chronological processing
+      events.forEach((event, index) => {
+        // Using type assertion to add timestamp property for test purposes
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (event as any).timestamp = new Date(baseTime + index * 1000);
+      });
+
+      // Act: Process events in order
+      const game = Game.fromEvents(events);
+
+      // Assert: Final state reflects proper ordering
+      expect(game.status).toBe(GameStatus.IN_PROGRESS);
+      expect(game.score.getHomeRuns()).toBe(3); // Should reflect final home score after all updates
+      expect(game.score.getAwayRuns()).toBe(1); // Should reflect final away score
+    });
+
+    it('should maintain domain invariants during reconstruction', () => {
+      // Arrange: Create events that could violate invariants if processed incorrectly
+      const gameEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Invariant', 'Test'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 2, { home: 2, away: 0 }),
+        new InningAdvanced(gameId, 1, false), // Must advance to bottom before next inning
+        new InningAdvanced(gameId, 2, true), // Now can advance to inning 2
+      ];
+
+      const lineupEvents: DomainEvent[] = [
+        new TeamLineupCreated(homeLineupId, gameId, 'HOME'),
+        new PlayerAddedToLineup(
+          gameId,
+          homeLineupId,
+          players[0]!.id,
+          players[0]!.jersey,
+          players[0]!.name,
+          1,
+          FieldPosition.FIRST_BASE
+        ),
+        new PlayerAddedToLineup(
+          gameId,
+          homeLineupId,
+          players[1]!.id,
+          players[1]!.jersey,
+          players[1]!.name,
+          2,
+          FieldPosition.SECOND_BASE
+        ),
+      ];
+
+      // Act: Reconstruct with invariant-sensitive events
+      const game = Game.fromEvents(gameEvents);
+      const lineup = TeamLineup.fromEvents(lineupEvents);
+
+      // Assert: All invariants maintained
+      expect(game.status).toBe(GameStatus.IN_PROGRESS);
+      expect(game.currentInning).toBe(2); // Proper inning advancement
+      expect(game.isTopHalf).toBe(true); // Proper half-inning state
+
+      const activeLineup = lineup.getActiveLineup();
+      expect(activeLineup).toHaveLength(2);
+      const jerseyNumbers = activeLineup.map(slot => slot.currentPlayer.toString());
+      expect(new Set(jerseyNumbers).size).toBe(jerseyNumbers.length); // All jersey numbers unique
+
+      expect(game.score.getHomeRuns()).toBe(2);
+      expect(game.score.getAwayRuns()).toBe(0);
+    });
+
+    it('should handle events from different aggregates interleaved', () => {
+      // Arrange: Create interleaved events from different aggregates
+      const gameEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Interleaved', 'Test'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+      ];
+
+      const lineupEvents: DomainEvent[] = [
+        new TeamLineupCreated(homeLineupId, gameId, 'HOME'),
+        new PlayerAddedToLineup(
+          gameId,
+          homeLineupId,
+          players[0]!.id,
+          players[0]!.jersey,
+          players[0]!.name,
+          1,
+          FieldPosition.FIRST_BASE
+        ),
+        new PlayerAddedToLineup(
+          gameId,
+          homeLineupId,
+          players[1]!.id,
+          players[1]!.jersey,
+          players[1]!.name,
+          2,
+          FieldPosition.SECOND_BASE
+        ),
+        new PlayerAddedToLineup(
+          gameId,
+          homeLineupId,
+          players[2]!.id,
+          players[2]!.jersey,
+          players[2]!.name,
+          3,
+          FieldPosition.THIRD_BASE
+        ),
+      ];
+
+      const inningEvents: DomainEvent[] = [new InningStateCreated(inningStateId, gameId, 1, true)];
+
+      // Act: Process separately (mimicking interleaved processing)
+      const game = Game.fromEvents(gameEvents);
+      const lineup = TeamLineup.fromEvents(lineupEvents);
+      const inning = InningState.fromEvents(inningEvents);
+
+      // Assert: Proper state despite interleaving
+      expect(game.status).toBe(GameStatus.IN_PROGRESS);
+      expect(game.score.getHomeRuns()).toBe(1);
+
+      expect(lineup.getActiveLineup()).toHaveLength(3); // All players added
+
+      expect(inning.inning).toBe(1);
+      expect(inning.isTopHalf).toBe(true);
+    });
+
+    it('should preserve aggregate boundaries during reconstruction', () => {
+      // Arrange: Create events that test aggregate boundary preservation
+      const otherGameId = TestGameFactory.createGameId('other');
+
+      const primaryGameEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Primary', 'Game'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+      ];
+
+      const otherGameEvents: DomainEvent[] = [
+        new GameCreated(otherGameId, 'Other', 'Game'),
+        new GameStarted(otherGameId),
+        new ScoreUpdated(otherGameId, 'AWAY', 2, { home: 0, away: 2 }),
+      ];
+
+      // Act: Reconstruct aggregates separately
+      const primaryGame = Game.fromEvents(primaryGameEvents);
+      const otherGame = Game.fromEvents(otherGameEvents);
+
+      // Assert: Proper boundary preservation
+      expect(primaryGame.homeTeamName).toBe('Primary');
+      expect(primaryGame.awayTeamName).toBe('Game');
+      expect(primaryGame.score.getHomeRuns()).toBe(1);
+      expect(primaryGame.score.getAwayRuns()).toBe(0);
+
+      expect(otherGame.homeTeamName).toBe('Other');
+      expect(otherGame.awayTeamName).toBe('Game');
+      expect(otherGame.score.getHomeRuns()).toBe(0);
+      expect(otherGame.score.getAwayRuns()).toBe(2);
+    });
+  });
+
+  describe('Complex Game Scenarios', () => {
+    it('should reconstruct 9-inning game with substitutions', () => {
+      // Arrange: Create a full 9-inning game
+      const events: DomainEvent[] = [
+        new GameCreated(gameId, 'Starters', 'Regulars'),
+        new GameStarted(gameId),
+      ];
+
+      // Simulate 9 innings with alternating scoring
+      for (let inning = 1; inning <= 9; inning++) {
+        events.push(new InningAdvanced(gameId, inning, true));
+
+        // Add some scoring
+        if (inning % 2 === 1) {
+          events.push(
+            new ScoreUpdated(gameId, 'AWAY', 1, {
+              home: Math.floor(inning / 2),
+              away: Math.floor((inning + 1) / 2),
+            })
+          );
+        } else {
+          events.push(
+            new ScoreUpdated(gameId, 'HOME', 1, {
+              home: Math.floor((inning + 1) / 2),
+              away: Math.floor(inning / 2),
+            })
+          );
+        }
+
+        events.push(new InningAdvanced(gameId, inning, false));
+      }
+
+      events.push(new GameCompleted(gameId, 'REGULATION', { home: 5, away: 4 }, 9));
+
+      // Act: Reconstruct 9-inning game
+      const game = Game.fromEvents(events);
+
+      // Assert: Complete 9-inning game reconstruction
+      expect(game.status).toBe(GameStatus.COMPLETED);
+      expect(game.currentInning).toBe(9);
+      expect(game.score.getHomeRuns()).toBe(5);
+      expect(game.score.getAwayRuns()).toBe(4);
+    });
+
+    it('should handle EXTRA_PLAYER scenarios with proper event replay', () => {
+      // Arrange: Create scenario with EXTRA_PLAYER rule
+      const lineupEvents: DomainEvent[] = [new TeamLineupCreated(homeLineupId, gameId, 'HOME')];
+
+      // Add standard 9 players
+      for (let i = 0; i < 9; i++) {
+        lineupEvents.push(
+          new PlayerAddedToLineup(
+            gameId,
+            homeLineupId,
+            players[i]!.id,
+            players[i]!.jersey,
+            players[i]!.name,
+            i + 1,
+            FieldPosition.LEFT_FIELD
+          )
+        );
+      }
+
+      // Add EXTRA_PLAYER (10th player)
+      lineupEvents.push(
+        new PlayerAddedToLineup(
+          gameId,
+          homeLineupId,
+          players[9]!.id,
+          players[9]!.jersey,
+          players[9]!.name,
+          10,
+          FieldPosition.EXTRA_PLAYER
+        )
+      );
+
+      const gameEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Standard', 'Extra'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+      ];
+
+      // Act: Reconstruct with EXTRA_PLAYER
+      const game = Game.fromEvents(gameEvents);
+      const lineup = TeamLineup.fromEvents(lineupEvents);
+
+      // Assert: EXTRA_PLAYER handling
+      expect(game.status).toBe(GameStatus.IN_PROGRESS);
+      expect(game.score.getHomeRuns()).toBe(1);
+
+      const activeLineup = lineup.getActiveLineup();
+      expect(activeLineup).toHaveLength(10); // Should have 10 players (including EXTRA_PLAYER)
+
+      const extraPlayer = activeLineup.find(slot => slot.currentPlayer.equals(players[9]!.id));
+      expect(extraPlayer).toBeDefined();
+      expect(extraPlayer?.position).toBe(10);
+    });
+
+    it('should maintain scoring consistency across aggregates', () => {
+      // Arrange: Create events with complex scoring scenarios
+      const gameEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Home', 'Away'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'AWAY', 1, { home: 0, away: 1 }),
+        new InningAdvanced(gameId, 1, false), // Switch to bottom half
+        new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 1 }),
+      ];
+
+      const inningEvents: DomainEvent[] = [new InningStateCreated(inningStateId, gameId, 1, true)];
+
+      // Act: Reconstruct with complex scoring
+      const game = Game.fromEvents(gameEvents);
+      const inning = InningState.fromEvents(inningEvents);
+
+      // Assert: Scoring consistency
+      expect(game.status).toBe(GameStatus.IN_PROGRESS);
+      expect(game.score.getHomeRuns()).toBe(1);
+      expect(game.score.getAwayRuns()).toBe(1);
+      // Verify tied game
+      expect(game.score.getHomeRuns()).toBe(game.score.getAwayRuns());
+
+      expect(game.isTopHalf).toBe(false); // Should be in bottom of inning
+      expect(inning.isTopHalf).toBe(true); // Inning state tracks original half
+    });
+
+    it('should support re-entry rules through event reconstruction', () => {
+      // Arrange: Create scenario testing lineup management
+      const lineupEvents: DomainEvent[] = [new TeamLineupCreated(homeLineupId, gameId, 'HOME')];
+
+      // Add starting players
+      for (let i = 0; i < 9; i++) {
+        lineupEvents.push(
+          new PlayerAddedToLineup(
+            gameId,
+            homeLineupId,
+            players[i]!.id,
+            players[i]!.jersey,
+            players[i]!.name,
+            i + 1,
+            FieldPosition.LEFT_FIELD
+          )
+        );
+      }
+
+      const gameEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Starters', 'Subs'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 2, { home: 2, away: 0 }),
+      ];
+
+      // Act: Reconstruct with lineup management
+      const lineup = TeamLineup.fromEvents(lineupEvents);
+      const game = Game.fromEvents(gameEvents);
+
+      // Assert: Proper reconstruction
+      const activeLineup = lineup.getActiveLineup();
+      expect(activeLineup).toHaveLength(9);
+
+      // All should be marked as starters (check if any history entry was a starter)
+      const starters = activeLineup.filter(slot => slot.history.some(h => h.wasStarter));
+      expect(starters).toHaveLength(9);
+
+      expect(game.status).toBe(GameStatus.IN_PROGRESS);
+      expect(game.score.getHomeRuns()).toBe(2);
+    });
+  });
+
+  describe('Performance & Edge Cases', () => {
+    it('should handle 1000+ events efficiently', () => {
+      const startTime = performance.now();
+
+      // Arrange: Create large event sequence
+      const events: DomainEvent[] = [
+        new GameCreated(gameId, 'Performance', 'Test'),
+        new GameStarted(gameId),
+      ];
+
+      // Generate 1000+ events simulating extensive gameplay
+      for (let i = 0; i < 1000; i++) {
+        // Alternate between home and away scoring
+        const team = i % 2 === 0 ? 'HOME' : 'AWAY';
+        const homeRuns = Math.floor((i + 1) / 2);
+        const awayRuns = Math.floor(i / 2);
+
+        events.push(new ScoreUpdated(gameId, team, 1, { home: homeRuns, away: awayRuns }));
+
+        // Occasionally advance innings
+        if (i % 20 === 0) {
+          const inning = Math.floor(i / 40) + 1;
+          const isTop = (i / 20) % 2 === 0;
+          events.push(new InningAdvanced(gameId, inning, isTop));
+        }
+      }
+
+      expect(events.length).toBeGreaterThan(1000);
+
+      // Act: Reconstruct from large event set
+      const game = Game.fromEvents(events);
+
+      const endTime = performance.now();
+      const executionTime = endTime - startTime;
+
+      // Assert: Performance and correctness
+      expect(executionTime).toBeLessThan(100); // Should complete in <100ms
+      expect(game.status).toBe(GameStatus.IN_PROGRESS);
+      expect(game.score.getHomeRuns()).toBeGreaterThan(0);
+      expect(game.score.getAwayRuns()).toBeGreaterThan(0);
+    });
+
+    it('should gracefully handle malformed event sequences', () => {
+      // Arrange: Create sequence with potential issues
+      const validEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Valid', 'Game'),
+        new GameStarted(gameId),
+        new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+      ];
+
+      // Act & Assert: Test various malformed scenarios
+
+      // Empty event array
+      expect(() => Game.fromEvents([])).toThrow(DomainError);
+
+      // Wrong first event type
+      const wrongFirstEvent = [new GameStarted(gameId), ...validEvents.slice(1)];
+      expect(() => Game.fromEvents(wrongFirstEvent)).toThrow(DomainError);
+
+      // Mixed aggregate IDs
+      const otherGameId = TestGameFactory.createGameId('other');
+      const mixedEvents = [
+        new GameCreated(gameId, 'Mixed', 'Game'),
+        new GameCreated(otherGameId, 'Other', 'Game'), // Wrong aggregate ID
+      ];
+      expect(() => Game.fromEvents(mixedEvents)).toThrow(DomainError);
+
+      // Valid sequence should work
+      expect(() => Game.fromEvents(validEvents)).not.toThrow();
+    });
+
+    it('should support time-travel to any point in game history', () => {
+      // Arrange: Create game history with multiple checkpoints
+      const allEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Time', 'Travel'),
+        new GameStarted(gameId), // Checkpoint 1: Game started
+        new ScoreUpdated(gameId, 'HOME', 3, { home: 3, away: 0 }),
+        new InningAdvanced(gameId, 2, true), // Checkpoint 2: Inning 2
+        new ScoreUpdated(gameId, 'AWAY', 2, { home: 3, away: 2 }),
+        new InningAdvanced(gameId, 7, false), // Checkpoint 3: Final inning
+        new GameCompleted(gameId, 'REGULATION', { home: 5, away: 4 }, 7), // Checkpoint 4: Game complete
+      ];
+
+      // Act: Time-travel to different points
+      const checkpoint1 = Game.fromEvents(allEvents.slice(0, 2)); // Just started
+      const checkpoint2 = Game.fromEvents(allEvents.slice(0, 4)); // Inning 2
+      const checkpoint3 = Game.fromEvents(allEvents.slice(0, 6)); // Final inning
+      const checkpoint4 = Game.fromEvents(allEvents); // Complete game
+
+      // Assert: Accurate time-travel
+      expect(checkpoint1.status).toBe(GameStatus.IN_PROGRESS);
+      expect(checkpoint1.currentInning).toBe(1);
+      expect(checkpoint1.score.getHomeRuns()).toBe(0);
+
+      expect(checkpoint2.status).toBe(GameStatus.IN_PROGRESS);
+      expect(checkpoint2.currentInning).toBe(2);
+      expect(checkpoint2.score.getHomeRuns()).toBe(3);
+
+      expect(checkpoint3.status).toBe(GameStatus.IN_PROGRESS);
+      expect(checkpoint3.currentInning).toBe(7);
+      expect(checkpoint3.score.getAwayRuns()).toBe(2);
+
+      expect(checkpoint4.status).toBe(GameStatus.COMPLETED);
+      expect(checkpoint4.score.getHomeRuns()).toBe(5);
+      expect(checkpoint4.score.getAwayRuns()).toBe(4);
+    });
+
+    it('should demonstrate undo/redo capability via event replay', () => {
+      // Arrange: Create sequence of actions that can be undone/redone
+      const baseEvents: DomainEvent[] = [
+        new GameCreated(gameId, 'Undo', 'Redo'),
+        new GameStarted(gameId),
+      ];
+
+      const actionEvents: DomainEvent[] = [
+        new ScoreUpdated(gameId, 'HOME', 1, { home: 1, away: 0 }),
+      ];
+
+      const undoEvents: DomainEvent[] = [
+        // Use a corrective score update (simulate undo via new total)
+        new ScoreUpdated(gameId, 'AWAY', 1, { home: 1, away: 1 }), // Balance the scores
+      ];
+
+      const redoEvents: DomainEvent[] = [
+        new ScoreUpdated(gameId, 'HOME', 1, { home: 2, away: 1 }), // "Redo" gives home the lead again
+      ];
+
+      // Act: Simulate undo/redo through event replay
+      const originalState = Game.fromEvents(baseEvents);
+      const afterAction = Game.fromEvents([...baseEvents, ...actionEvents]);
+      const afterUndo = Game.fromEvents([...baseEvents, ...actionEvents, ...undoEvents]);
+      const afterRedo = Game.fromEvents([
+        ...baseEvents,
+        ...actionEvents,
+        ...undoEvents,
+        ...redoEvents,
+      ]);
+
+      // Assert: Undo/redo functionality via event replay
+      expect(originalState.score.getHomeRuns()).toBe(0);
+      expect(afterAction.score.getHomeRuns()).toBe(1);
+      expect(afterUndo.score.getHomeRuns()).toBe(1); // Tied state after "undo"
+      expect(afterUndo.score.getAwayRuns()).toBe(1); // Away team caught up
+      expect(afterRedo.score.getHomeRuns()).toBe(2); // Home team takes lead again
+      expect(afterRedo.score.getAwayRuns()).toBe(1);
+    });
+  });
+});

--- a/packages/domain/src/value-objects/GameScore.ts
+++ b/packages/domain/src/value-objects/GameScore.ts
@@ -104,6 +104,15 @@ export class GameScore {
   }
 
   /**
+   * Determines if both teams have zero runs (0-0 score).
+   *
+   * @returns True if both teams have zero runs, false otherwise
+   */
+  isZero(): boolean {
+    return this.homeScore.runs === 0 && this.awayScore.runs === 0;
+  }
+
+  /**
    * Calculates the run differential from the home team's perspective.
    *
    * @returns Positive number if home team is winning, negative if away team is winning, zero if tied


### PR DESCRIPTION
## Summary
- Implements complete event sourcing pattern for all three domain aggregates (Game, TeamLineup, InningState)
- Adds `fromEvents()` and `applyEvent()` methods to reconstruct state from event streams
- Provides comprehensive test coverage with 2,400+ new test lines and integration scenarios

## Changes
- ✅ **Game aggregate**: Event sourcing with full state reconstruction and game flow management
- ✅ **TeamLineup aggregate**: Event replay for lineup management, substitutions, and roster tracking
- ✅ **InningState aggregate**: Event-based state transitions for innings, at-bats, and scoring
- ✅ **Integration tests**: End-to-end event sourcing scenarios across all aggregates
- ✅ **Documentation**: Updated event sourcing design documentation and architecture guidelines

## Technical Details
- **Event Replay**: All aggregates support complete state reconstruction from event streams
- **State Consistency**: Event sourcing ensures perfect audit trail and state reproducibility
- **Performance**: Efficient event application with optimized state transitions
- **Type Safety**: Full TypeScript coverage with strict typing for all event handlers

## Test Coverage
- **1,054 lines** of Game aggregate tests (event sourcing, state reconstruction)
- **1,617 lines** of TeamLineup aggregate tests (lineup management, substitutions)
- **756 lines** of InningState aggregate tests (inning flow, scoring mechanics)
- **675 lines** of integration tests (cross-aggregate scenarios)
- **>95% coverage** maintained across all domain aggregates

## Test Plan
- [x] Unit tests for each aggregate's event sourcing implementation
- [x] Integration tests for complete game scenarios with multiple aggregates
- [x] Event replay consistency validation across state reconstructions
- [x] State reconstruction accuracy for complex game scenarios
- [x] Type safety validation for all event handlers and state transitions

🤖 Generated with [Claude Code](https://claude.ai/code)